### PR TITLE
Avoid WARN message during 'build' task execution. 'prepublish' task i…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "OpenAds: Advertising library",
     "main": "dist/",
     "scripts": {
-        "prepublish": "rm -Rf ./dist && npm run build",
+        "prepare": "rm -Rf ./dist && npm run build",
+        "prepublishOnly": "rm -Rf ./dist && npm run build",
         "build": "babel src --ignore test,legacy --out-dir dist ",
         "test": "mocha --recursive --require babel-polyfill --compilers js:babel-register \"src/test/**/*.js\" || true",
         "watch:js": "onchange src/*.js -- npm run build",


### PR DESCRIPTION
…s deprecated and divided into two separated tasks: 'prepare' for build process, 'prepublishOnly' for publish process.