### PR TITLE
Add the capability to restore connectors initial state

### DIFF
--- a/src/openads/application/OpenAds.js
+++ b/src/openads/application/OpenAds.js
@@ -48,6 +48,10 @@ export default class OpenAds {
     })
   }
 
+  resetConnectors () {
+    this._container.getInstance({key: 'ResetConnectorsUseCase'}).resetConnectors()
+  }
+
   environment () {
     return this._container.config
   }

--- a/src/openads/application/service/ResetConnectorsUseCase.js
+++ b/src/openads/application/service/ResetConnectorsUseCase.js
@@ -1,0 +1,8 @@
+export default class ResetConnectorsUseCase {
+  constructor ({adChainedRepository}) {
+    this._adChainedRepository = adChainedRepository
+  }
+  resetConnectors () {
+    this._adChainedRepository.reset()
+  }
+}

--- a/src/openads/domain/ad/AdRepository.js
+++ b/src/openads/domain/ad/AdRepository.js
@@ -10,4 +10,11 @@ export default class AdRepository {
   findAd ({adRequest}) {
     throw new Error('AdRepository#findAd must be implemented')
   }
+
+  /**
+   * Resets any internal state to initial state
+   */
+  reset () {
+    throw new Error('AdRepository#reset must be implemented')
+  }
 }

--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -9,6 +9,7 @@ import AppNexusBannerRenderer from '../service/appnexus/AppNexusBannerRenderer'
 import FindAdUseCase from '../../application/service/FindAdUseCase'
 import AppNexusClient from '../connector/appnexus/AppNexusClient'
 import EventDispatcher from '../service/EventDispatcher'
+import ResetConnectorsUseCase from '../../application/service/ResetConnectorsUseCase'
 
 export default class Container {
   constructor ({config}) {
@@ -36,6 +37,12 @@ export default class Container {
 
   _buildFindAdsUseCase () {
     return new FindAdUseCase({
+      adChainedRepository: this.getInstance({key: 'AdChainedRepository'})
+    })
+  }
+
+  _buildResetConnectorsUseCase () {
+    return new ResetConnectorsUseCase({
       adChainedRepository: this.getInstance({key: 'AdChainedRepository'})
     })
   }

--- a/src/openads/infrastructure/connector/appnexus/AppNexusConnector.js
+++ b/src/openads/infrastructure/connector/appnexus/AppNexusConnector.js
@@ -54,4 +54,11 @@ export default class AppNexusConnector extends Connector {
   showTag ({target}) {
     throw new Error('AppNexusConnector#showTag must be implemented')
   }
+
+  /**
+   * Resets the state to it's pre uninitialized state.
+   */
+  clearRequest () {
+    throw new Error('AppNexusConnector#clearRequest must be implemented')
+  }
 }

--- a/src/openads/infrastructure/connector/appnexus/AppNexusConnectorImpl.js
+++ b/src/openads/infrastructure/connector/appnexus/AppNexusConnectorImpl.js
@@ -42,4 +42,9 @@ export default class AppNexusConnectorImpl extends AppNexusConnector {
     this._appNexusClient.anq.push(() => this._appNexusClient.showTag(target))
     return this
   }
+
+  clearRequest () {
+    this._appNexusClient.anq.push(() => this._appNexusClient.clearRequest())
+    return this
+  }
 }

--- a/src/openads/infrastructure/repository/AdChainedRepository.js
+++ b/src/openads/infrastructure/repository/AdChainedRepository.js
@@ -16,4 +16,8 @@ export default class AdChainedRepository extends AdRepository {
   findAd ({adRequest}) {
     return this._appnexusRepository.findAd({adRequest})
   }
+
+  reset () {
+    this._appnexusRepository.reset()
+  }
 }

--- a/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
+++ b/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
@@ -48,4 +48,8 @@ export default class AppNexusAdRepository extends AdRepository {
         .loadTags()
     })
   }
+
+  reset () {
+    this._connector.clearRequest()
+  }
 }


### PR DESCRIPTION
This PR will:
* Add the option to reset the connectors to an initial state. 

AppNexus connector for example, mantains an internal state into the apntag object that doesn't allow to reload ads into a single page application. It's API offers a clearRequest method to clean that data. For custom connectors, it would be nice to support the reset method (forced by interface)