### PR TITLE
Fix Reset connectors use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,22 @@ openAds.registerHook(sampleHook)
 // unregisitering the hook
 openAds.registerHook(sampleHook)
 ```
-  
+
+## Single Page Application Support
+
+OpenAds supports reloading Ads after page fragments refresh, commonly used in SPA websites.
+In order to do that, just call:
+```ecmascript 6
+// will clean any internal state of supported source connectors
+openAds.resetConnectors()
+```
+
 # Roadmap
 
 * Add support for Native Ads
 * Add support to Google AdSense
 * Add support for passback sources 
+* Add support for single Ad position refresh 
 
 
 # License

--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -71,7 +71,6 @@ export default class Container {
   }
   _buildAdChainedRepository () {
     return new AdChainedRepository({
-      googleRepository: null,
       appnexusRepository: this.getInstance({key: 'AppNexusRepository'}),
       configuration: this._config
     })

--- a/src/openads/infrastructure/connector/appnexus/AppNexusConnector.js
+++ b/src/openads/infrastructure/connector/appnexus/AppNexusConnector.js
@@ -58,7 +58,7 @@ export default class AppNexusConnector extends Connector {
   /**
    * Resets the state to it's pre uninitialized state.
    */
-  clearRequest () {
+  reset () {
     throw new Error('AppNexusConnector#clearRequest must be implemented')
   }
 }

--- a/src/openads/infrastructure/repository/AdChainedRepository.js
+++ b/src/openads/infrastructure/repository/AdChainedRepository.js
@@ -1,10 +1,9 @@
 import AdRepository from '../../domain/ad/AdRepository'
 
 export default class AdChainedRepository extends AdRepository {
-  constructor ({appnexusRepository, googleRepository, configuration}) {
+  constructor ({appnexusRepository, configuration}) {
     super()
     this._appnexusRepository = appnexusRepository
-    this._googleRepository = googleRepository
     this._configuration = configuration
   }
 

--- a/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
+++ b/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
@@ -48,6 +48,6 @@ export default class AppNexusAdRepository extends AdRepository {
   }
 
   reset () {
-    this._connector.clearRequest()
+    this._connector.reset()
   }
 }

--- a/src/test/openads/application/service/ResetConnectorsUseCaseTest.js
+++ b/src/test/openads/application/service/ResetConnectorsUseCaseTest.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-unused-expressions */
+import {expect} from 'chai'
+import sinon from 'sinon'
+import ResetConnectorsUseCase from '../../../../openads/application/service/ResetConnectorsUseCase'
+
+describe('Reset Connectors use case', function () {
+  it('Should reset the repository', function () {
+    const adChainedRepository = {
+      reset: () => null
+    }
+    const adChainedRepositoryResetSpy = sinon.spy(adChainedRepository, 'reset')
+
+    const useCase = new ResetConnectorsUseCase({adChainedRepository})
+    useCase.resetConnectors()
+    expect(adChainedRepositoryResetSpy.calledOnce).to.be.true
+  })
+})

--- a/src/test/openads/infrastructure/appnexus/AppNexusConnectorTest.js
+++ b/src/test/openads/infrastructure/appnexus/AppNexusConnectorTest.js
@@ -122,4 +122,58 @@ describe('AppNexusConnectorImpl implementation', function () {
       expect(mutatedAppNexusConnector).to.be.an.instanceof(AppNexusConnectorImpl)
     })
   })
+  describe('Given two events registered for two different targets', () => {
+    beforeEach('Define the events', () => {
+      this.givenEvent11 = {event: 'event1', targetId: 'target1', callback: () => null}
+      this.givenEvent12 = {event: 'event1', targetId: 'target2', callback: () => null}
+      this.givenEvent21 = {event: 'event2', targetId: 'target1', callback: () => null}
+      this.givenEvent22 = {event: 'event2', targetId: 'target2', callback: () => null}
+    })
+    describe('Registering the events', () => {
+      it('Should register the events to the appnexus client', () => {
+        const appNexusQueue = {
+          push: (f) => f()
+        }
+        const appNexusClientMock = {
+          anq: appNexusQueue,
+          clearRequest: () => null,
+          offEvent: () => null,
+          onEvent: () => null
+        }
+        const onEventSpy = sinon.spy(appNexusClientMock, 'onEvent')
+
+        const appNexusConnector = new AppNexusConnectorImpl({appNexusClient: appNexusClientMock, source: {}, connectorData: {}})
+        appNexusConnector.onEvent(this.givenEvent11)
+        appNexusConnector.onEvent(this.givenEvent12)
+        appNexusConnector.onEvent(this.givenEvent21)
+        appNexusConnector.onEvent(this.givenEvent22)
+
+        expect(onEventSpy.callCount).to.equal(4)
+      })
+    })
+    describe('Calling the reset method', () => {
+      it('Should clear the requests and the registered events', () => {
+        const appNexusQueue = {
+          push: (f) => f()
+        }
+        const appNexusClientMock = {
+          anq: appNexusQueue,
+          clearRequest: () => null,
+          offEvent: () => null,
+          onEvent: () => null
+        }
+        const offEventSpy = sinon.spy(appNexusClientMock, 'offEvent')
+
+        const appNexusConnector = new AppNexusConnectorImpl({appNexusClient: appNexusClientMock, source: {}, connectorData: {}})
+        appNexusConnector.onEvent(this.givenEvent11)
+        appNexusConnector.onEvent(this.givenEvent12)
+        appNexusConnector.onEvent(this.givenEvent21)
+        appNexusConnector.onEvent(this.givenEvent22)
+
+        appNexusConnector.reset()
+
+        expect(offEventSpy.callCount).to.equal(4)
+      })
+    })
+  })
 })

--- a/src/test/openads/infrastructure/repository/AdChainedRepositoryTest.js
+++ b/src/test/openads/infrastructure/repository/AdChainedRepositoryTest.js
@@ -12,7 +12,6 @@ describe('Ad Chained repository', function () {
       }
       const adChainedRepository = new AdChainedRepository({
         appnexusRepository: appNexusRepositoryMock,
-        googleRepository: {},
         configuration: {}
       })
 
@@ -29,7 +28,6 @@ describe('Ad Chained repository', function () {
       const findAdSpy = sinon.spy(appNexusRepositoryMock, 'findAd')
       const adChainedRepository = new AdChainedRepository({
         appnexusRepository: appNexusRepositoryMock,
-        googleRepository: {},
         configuration: {}
       })
 
@@ -41,6 +39,22 @@ describe('Ad Chained repository', function () {
           done()
         })
         .catch(error => done(error))
+    })
+  })
+  describe('Calling the reset method', function () {
+    it('Should reset all chained repositories', function () {
+      const appNexusRepositoryMock = {
+        reset: () => null
+      }
+      const adChainedRepositoryResetSpy = sinon.spy(appNexusRepositoryMock, 'reset')
+
+      const adChainedRepository = new AdChainedRepository({
+        appnexusRepository: appNexusRepositoryMock,
+        configuration: {}
+      })
+      adChainedRepository.reset()
+
+      expect(adChainedRepositoryResetSpy.calledOnce).to.be.true
     })
   })
 })

--- a/src/test/openads/infrastructure/repository/appnexus/AppNexusAdRepositoryTest.js
+++ b/src/test/openads/infrastructure/repository/appnexus/AppNexusAdRepositoryTest.js
@@ -13,16 +13,17 @@ describe('AppNexus repository', function () {
         return this.appNexusConnectorMock
       },
       defineTag: ({data}) => this.appNexusConnectorMock,
-      loadTags: () => this.appNexusConnectorMock
+      loadTags: () => this.appNexusConnectorMock,
+      reset: () => null
     }
     this.appNexusResultMapperMock = {
       mapResponseToDomain: ({appNexusResponse}) => {}
     }
     this.activateDebugModeSpy = sinon.spy(this.appNexusConnectorMock, 'activateDebugMode')
-    this.setPageOptsSpy = sinon.spy(this.appNexusConnectorMock, 'setPageOpts')
     this.onEventSpy = sinon.spy(this.appNexusConnectorMock, 'onEvent')
     this.defineTagSpy = sinon.spy(this.appNexusConnectorMock, 'defineTag')
     this.loadTagsSpy = sinon.spy(this.appNexusConnectorMock, 'loadTags')
+    this.resetSpy = sinon.spy(this.appNexusConnectorMock, 'reset')
     this.mapResponseToDomainSpy = sinon.spy(this.appNexusResultMapperMock, 'mapResponseToDomain')
   })
   describe('given a valid adRequest', function () {
@@ -87,6 +88,16 @@ describe('AppNexus repository', function () {
           console.log(err)
           done()
         })
+    })
+  })
+
+  describe('Calling the reset method', function () {
+    it('Should reset the connector', function () {
+      const appnexusRepository = new AppNexusAdRepository({
+        appNexusConnector: this.appNexusConnectorMock
+      })
+      appnexusRepository.reset()
+      expect(this.resetSpy.calledOnce).to.be.true
     })
   })
 })


### PR DESCRIPTION
Unregisters all events from AppNexus’ apntag when reseting the connector for SPA usage

* FIX: when reloading ads in SPA, the find use case registers the adAvailable event to the targetId, if it’s not cleaned before reloading, it will be emitted two times:
- the first emit tries to show the Ad but is canceled when the second emit starts
- the second emit tries to show the Ad but internal apntag state will prevent to show the Ad as it thinks that first show is running
So no Ad will be refreshed at all, if the connector is not reset before reloading.