### PR TITLE
Support for 'video' Ads returned by AppNexus

### DIFF
--- a/src/openads/infrastructure/service/appnexus/AppNexusResultMapper.js
+++ b/src/openads/infrastructure/service/appnexus/AppNexusResultMapper.js
@@ -32,6 +32,14 @@ export default class AppNexusResultMapper {
           })
         })
       }
+      case 'video': {
+        return this._bannerFactory.create({
+          containerId: appNexusResponse.targetId,
+          position: position,
+          source: 'AppNexus',
+          content: appNexusResponse.video.content
+        })
+      }
       default: {
         throw new Error('AdType not supported: ' + appNexusResponse.adType)
       }

--- a/src/test/openads/infrastructure/service/appnexus/AppNexusResultMapperTest.js
+++ b/src/test/openads/infrastructure/service/appnexus/AppNexusResultMapperTest.js
@@ -40,6 +40,36 @@ describe('AppNexus result mapper', function () {
     })
   })
 
+  describe('given a video reponse type from AppNexus', function () {
+    it('should return a Banner domain object', function () {
+      const appNexusResultMapper = new AppNexusResultMapper({
+        bannerFactory: new BannerFactory({
+          appNexusBannerRenderer: {}
+        })
+      })
+
+      const givenContent = '<html></html>'
+      const givenPosition = 'da_position'
+      const givenTargetId = 'pepe_id'
+      const givenAdType = 'video'
+      const banner = appNexusResultMapper.mapResponseToDomain({
+        position: givenPosition,
+        appNexusResponse: {
+          targetId: givenTargetId,
+          adType: givenAdType,
+          video: {
+            content: givenContent
+          }
+        }
+      })
+
+      expect(banner).to.be.an.instanceof(Banner)
+      expect(banner.content).to.be.equals(givenContent)
+      expect(banner.containerId).to.be.equals(givenTargetId)
+      expect(banner.position).to.be.equals(givenPosition)
+    })
+  })
+
   describe('given any different reponse type of banner from AppNexus', function () {
     it('should return an exception', function () {
       const appNexusResultMapper = new AppNexusResultMapper({


### PR DESCRIPTION
This PR will:
* Add AppNexus adType ‘video’ as accepted Banner result
* By the moment, it will be returned as Banner, as it can be shown directly as any other html banner Ad.