### PR TITLE
Remove the activateDebugMode in AppNexus Repository

### DIFF
--- a/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
+++ b/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
@@ -20,7 +20,6 @@ export default class AppNexusAdRepository extends AdRepository {
   findAd ({adRequest}) {
     return new Promise((resolve, reject) => {
       this._connector
-        .activateDebugMode()
         .onEvent({
           event: 'adAvailable',
           targetId: adRequest.containerId,

--- a/src/test/openads/infrastructure/repository/appnexus/AppNexusAdRepositoryTest.js
+++ b/src/test/openads/infrastructure/repository/appnexus/AppNexusAdRepositoryTest.js
@@ -19,7 +19,6 @@ describe('AppNexus repository', function () {
     this.appNexusResultMapperMock = {
       mapResponseToDomain: ({appNexusResponse}) => {}
     }
-    this.activateDebugModeSpy = sinon.spy(this.appNexusConnectorMock, 'activateDebugMode')
     this.onEventSpy = sinon.spy(this.appNexusConnectorMock, 'onEvent')
     this.defineTagSpy = sinon.spy(this.appNexusConnectorMock, 'defineTag')
     this.loadTagsSpy = sinon.spy(this.appNexusConnectorMock, 'loadTags')
@@ -51,7 +50,6 @@ describe('AppNexus repository', function () {
         adRequest: givenAdRequest
       })
         .then(ad => {
-          expect(this.activateDebugModeSpy.calledOnce, 'activateDebugMode not called once').to.be.true
           expect(this.onEventSpy.calledTwice, 'onEvent not called twice').to.be.true
           expect(this.defineTagSpy.calledOnce, 'defineTag not called once').to.be.true
           expect(this.loadTagsSpy.calledOnce, 'loadTags not called once').to.be.true


### PR DESCRIPTION
This PR will:
- Remove the activateDebugMode from the findAd method, as it was being executed each time
- By the moment using apntag.debug=true from console is the option to debug the connector