### PR TITLE
Add the writeClickTrackers directly to the OpenAds Native Renderer

### DIFF
--- a/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
+++ b/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
@@ -19,7 +19,7 @@ export default class AppNexusAdRepository extends AdRepository {
    */
   findAd ({adRequest}) {
     return new Promise((resolve, reject) => {
-      if (adRequest.position === 'NATIVE_TEST') {
+      if (adRequest.position === 'NATIVE_DESKTOP' || adRequest.position === 'NATIVE_MOBILE') {
         resolve(this._appNexusResultMapper.mapResponseToDomain({
           position: adRequest.position,
           appNexusResponse: {

--- a/src/test/openads/domain/native/NativeRendererTest.js
+++ b/src/test/openads/domain/native/NativeRendererTest.js
@@ -4,12 +4,11 @@ import sinon from 'sinon'
 import NativeRenderer from '../../../../openads/domain/ad/native/NativeRenderer'
 
 describe('Native Renderer', () => {
-  describe('Given valid containerId, json, impressionTrackings and clickTrackings', () => {
+  describe('Given valid containerId, json and impressionTrackings', () => {
     it('Should call to the client render method and print the impression trackings', () => {
       const givenContainerId = 'test'
       const givenJson = {a: 'json'}
       const givenImpressionTrackers = ['url_i1', 'url_i2']
-      const givenClickTrackers = ['url_t1', 'url_t2', 'url_t3']
 
       const createElementMock = (e) => {
         let element = {
@@ -26,9 +25,68 @@ describe('Native Renderer', () => {
         createElement: (e) => createElementMock(e)
       }
 
-      const clientRendererSpy = sinon.spy()
+      const rendererMock = {
+        rendererFunction: ({json}) => {
+          return {
+            html: 'hello',
+            clickElementId: 'id'
+          }
+        }
+      }
+      const clientRendererFunctionSpy = sinon.spy(rendererMock, 'rendererFunction')
+
       const nativeRenderer = new NativeRenderer({
-        clientRenderer: clientRendererSpy,
+        clientRenderer: rendererMock.rendererFunction,
+        domDriver: domDriverMock
+      })
+
+      nativeRenderer.render({
+        containerId: givenContainerId,
+        json: givenJson,
+        impressionTrackers: givenImpressionTrackers
+      })
+
+      expect(clientRendererFunctionSpy.calledOnce).to.be.true
+      expect(clientRendererFunctionSpy.getCall(0).args[0].json).to.deep.equal(givenJson)
+
+      expect(container._appendedChildren.length).to.equal(givenImpressionTrackers.length)
+    })
+  })
+  describe('Given valid containerId, json and impressionTrackings and providing clickTrackers', () => {
+    it('Should register a method to the returned clickElementId that write clickTrackers to container if previous onclick was not defined on it', () => {
+      const givenContainerId = 'test'
+      const givenClickElementId = 'clickable'
+      const givenJson = {a: 'json'}
+      const givenImpressionTrackers = ['url_i1', 'url_i2']
+      const givenClickTrackers = ['url_t1', 'url_t2']
+
+      const createElementMock = (e) => {
+        let element = {
+          _appendedChildren: []
+        }
+        element.appendChild = (c) => element._appendedChildren.push(c)
+        return element
+      }
+      const container = createElementMock()
+      const clickable = createElementMock()
+      const domDriverMock = {
+        getElementById: ({id}) => {
+          return id === givenContainerId ? container : id === givenClickElementId ? clickable : null
+        },
+        createElement: (e) => createElementMock(e)
+      }
+
+      const rendererMock = {
+        rendererFunction: ({json}) => {
+          return {
+            html: 'hello',
+            clickElementId: givenClickElementId
+          }
+        }
+      }
+
+      const nativeRenderer = new NativeRenderer({
+        clientRenderer: rendererMock.rendererFunction,
         domDriver: domDriverMock
       })
 
@@ -39,16 +97,66 @@ describe('Native Renderer', () => {
         clickTrackers: givenClickTrackers
       })
 
-      expect(clientRendererSpy.calledOnce).to.be.true
-      expect(clientRendererSpy.getCall(0).args[0].json).to.deep.equal(givenJson)
-      expect(clientRendererSpy.getCall(0).args[0].writeClickTrackers).to.be.a('function')
+      expect(clickable.onclick).not.undefined
 
-      expect(container._appendedChildren.length).to.equal(givenImpressionTrackers.length)
+      clickable.onclick()
 
-      // if we call the writeClickTrackers function it should add the pixels to the container also
-      const writeClickTrackers = clientRendererSpy.getCall(0).args[0].writeClickTrackers
-      writeClickTrackers()
       expect(container._appendedChildren.length).to.equal(givenImpressionTrackers.length + givenClickTrackers.length)
+    })
+    it('Should register a method to the returned clickElementId that write clickTrackers to container and call previous element onclickif previous onclick was defined on it', () => {
+      const givenContainerId = 'test'
+      const givenClickElementId = 'clickable'
+      const givenJson = {a: 'json'}
+      const givenImpressionTrackers = ['url_i1', 'url_i2']
+      const givenClickTrackers = ['url_t1', 'url_t2']
+
+      const createElementMock = (e) => {
+        let element = {
+          _appendedChildren: []
+        }
+        element.appendChild = (c) => element._appendedChildren.push(c)
+        return element
+      }
+      const container = createElementMock()
+      const clickable = createElementMock()
+      clickable.onclick = () => null
+
+      const clickableClickSpy = sinon.spy(clickable, 'onclick')
+
+      const domDriverMock = {
+        getElementById: ({id}) => {
+          return id === givenContainerId ? container : id === givenClickElementId ? clickable : null
+        },
+        createElement: (e) => createElementMock(e)
+      }
+
+      const rendererMock = {
+        rendererFunction: ({json}) => {
+          return {
+            html: 'hello',
+            clickElementId: givenClickElementId
+          }
+        }
+      }
+
+      const nativeRenderer = new NativeRenderer({
+        clientRenderer: rendererMock.rendererFunction,
+        domDriver: domDriverMock
+      })
+
+      nativeRenderer.render({
+        containerId: givenContainerId,
+        json: givenJson,
+        impressionTrackers: givenImpressionTrackers,
+        clickTrackers: givenClickTrackers
+      })
+
+      expect(clickable.onclick).not.undefined
+
+      clickable.onclick()
+
+      expect(container._appendedChildren.length).to.equal(givenImpressionTrackers.length + givenClickTrackers.length)
+      expect(clickableClickSpy.calledOnce).to.be.true
     })
   })
 })


### PR DESCRIPTION
This PR moves the write click trackers from the client renderer to OpenAds to facilitate how they should be renderer.
In most situations, talking about native, the impression and click trackers will come from 3rd party servers (RTB) so moving the click trackers out of the client side and taking the responsability to register the proper function to do so directly in OpenAds seems nice.

So, merging this PR will:
* force the client renderer to return an object with the renderer HTML and the ID of the DOM element that is clickable if it wants to use the writeClickTrackers functionality
* enable OpenAds renderer to write the HTML, the impression trackers and register the function to write trackers for a given element ID and HTML as client response to native rendering request