### PR TITLE
AppNexus - Clean the container innerHTML before showing new Banner

### DIFF
--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -88,7 +88,8 @@ export default class Container {
   }
   _buildAppNexusBannerRenderer () {
     return new AppNexusBannerRenderer({
-      appNexusConnector: this.getInstance({key: 'AppNexusConnector'})
+      appNexusConnector: this.getInstance({key: 'AppNexusConnector'}),
+      domDriver: this.getInstance({key: 'DOMDriver'})
     })
   }
 

--- a/src/openads/infrastructure/service/appnexus/AppNexusBannerRenderer.js
+++ b/src/openads/infrastructure/service/appnexus/AppNexusBannerRenderer.js
@@ -4,14 +4,17 @@ export default class AppNexusBannerRenderer extends BannerRenderer {
     /**
      *
      * @param {AppNexusConnector} appNexusConnector
+     * @param {DOMDriver} domDriver
      */
-  constructor ({appNexusConnector}) {
+  constructor ({appNexusConnector, domDriver}) {
     super()
     this._appNexusConnector = appNexusConnector
+    this._domDriver = domDriver
   }
 
   render ({containerId}) {
     return new Promise((resolve, reject) => {
+      this._cleanContainer({containerId})
       this._appNexusConnector
         .onEvent({
           event: 'adLoaded',
@@ -20,5 +23,12 @@ export default class AppNexusBannerRenderer extends BannerRenderer {
         })
         .showTag({target: containerId})
     })
+  }
+
+  _cleanContainer ({containerId}) {
+    const container = this._domDriver.getElementById({id: containerId})
+    if (container !== null) {
+      container.innerHTML = ''
+    }
   }
 }

--- a/src/test/openads/infrastructure/service/appnexus/AppNexusBannerRendererTest.js
+++ b/src/test/openads/infrastructure/service/appnexus/AppNexusBannerRendererTest.js
@@ -2,9 +2,9 @@
 import {expect} from 'chai'
 import AppNexusBannerRenderer from '../../../../../openads/infrastructure/service/appnexus/AppNexusBannerRenderer'
 
-describe('AppNexus Banner Renderer', function () {
-  describe('given a DOM id node', function () {
-    it('should return a promise', function () {
+describe('AppNexus Banner Renderer', () => {
+  describe('given a DOM id node', () => {
+    it('should return a promise', () => {
       const givenContainerId = 'div_id_target'
       const appNexusConnectorMock = {
         onEvent: ({
@@ -16,9 +16,13 @@ describe('AppNexus Banner Renderer', function () {
         },
         showTag: ({target}) => appNexusConnectorMock
       }
+      const domDriverMock = {
+        getElementById: () => null
+      }
 
       const appNexusBannerRenderer = new AppNexusBannerRenderer({
-        appNexusConnector: appNexusConnectorMock
+        appNexusConnector: appNexusConnectorMock,
+        domDriver: domDriverMock
       })
 
       expect(appNexusBannerRenderer.render({
@@ -38,9 +42,13 @@ describe('AppNexus Banner Renderer', function () {
         },
         showTag: ({target}) => appNexusConnectorMock
       }
+      const domDriverMock = {
+        getElementById: () => null
+      }
 
       const appNexusBannerRenderer = new AppNexusBannerRenderer({
-        appNexusConnector: appNexusConnectorMock
+        appNexusConnector: appNexusConnectorMock,
+        domDriver: domDriverMock
       })
 
       appNexusBannerRenderer.render({
@@ -51,6 +59,32 @@ describe('AppNexus Banner Renderer', function () {
           done()
         })
         .catch(error => done(error))
+    })
+    it('should clean the container inner html', function (done) {
+      const givenContainerId = 'div_id_target'
+      const appNexusConnectorMock = {
+        onEvent: ({event, targetId, callback}) => {
+          callback()
+          return appNexusConnectorMock
+        },
+        showTag: ({target}) => appNexusConnectorMock
+      }
+      const containerMock = {innerHTML: 'this is the previous inner html'}
+      const domDriverMock = {
+        getElementById: () => containerMock
+      }
+
+      const appNexusBannerRenderer = new AppNexusBannerRenderer({
+        appNexusConnector: appNexusConnectorMock,
+        domDriver: domDriverMock
+      })
+
+      appNexusBannerRenderer.render({
+        containerId: givenContainerId
+      }).then(() => {
+        expect(containerMock.innerHTML).to.equal('')
+        done()
+      }).catch(error => done(error))
     })
   })
 })


### PR DESCRIPTION
Add a common requirement for AppNexus banner renderer: clean the container

* Now AppNexus Banner renderer will clean the container before showing the banner
* It avoids a common problem in event based refreshes where old innerHTML in container is kept and causing problems where showing a new Ad on it