### PR TITLE
Add the viewability trackers in the NativeRenderer

### DIFF
--- a/src/openads/domain/ad/native/Native.js
+++ b/src/openads/domain/ad/native/Native.js
@@ -7,10 +7,13 @@ export default class Native extends Ad {
      * @param {string} position
      * @param {string} source
      * @param {string} json
+     * @param {Array} impressionTrackers
+     * @param {Array} clickTrackers
+     * @param {string} viewabilityTrackers
      * @param {NativeRenderer} renderer
      * @param {EventDispatcher} eventDispatcher
      */
-  constructor ({containerId, position, source, json, impressionTrackers, clickTrackers, renderer, eventDispatcher}) {
+  constructor ({containerId, position, source, json, impressionTrackers, clickTrackers, viewabilityTrackers, renderer, eventDispatcher}) {
     super()
     this._containerId = containerId
     this._position = position
@@ -18,6 +21,7 @@ export default class Native extends Ad {
     this._json = json
     this._impressionTrackers = impressionTrackers
     this._clickTrackers = clickTrackers
+    this._viewabilityTrackers = viewabilityTrackers
     this._renderer = renderer
     this._eventDispatcher = eventDispatcher
   }
@@ -32,7 +36,8 @@ export default class Native extends Ad {
       containerId: this._containerId,
       json: this._json,
       impressionTrackers: this._impressionTrackers,
-      clickTrackers: this._clickTrackers
+      clickTrackers: this._clickTrackers,
+      viewabilityTrackers: this._viewabilityTrackers
     })
   }
 

--- a/src/openads/domain/ad/native/NativeFactory.js
+++ b/src/openads/domain/ad/native/NativeFactory.js
@@ -1,16 +1,27 @@
 import Native from './Native'
 
 export default class NativeFactory {
-    /**
-     *
-     * @param {NativeRendererProcessor} renderer
-     */
+  /**
+   *
+   * @param {NativeRendererProcessor} renderer
+   */
   constructor ({nativeRendererProcessor, eventDispatcher}) {
     this._nativeRendererProcessor = nativeRendererProcessor
     this._eventDispatcher = eventDispatcher
   }
 
-  create ({containerId, position, source, json, impressionTrackers, clickTrackers}) {
+  /**
+   *
+   * @param {string} containerId
+   * @param {string} position
+   * @param {string} source
+   * @param {Object} json
+   * @param {Array} impressionTrackers
+   * @param {Array} clickTrackers
+   * @param {string} viewabilityTrackers
+   * @return {Native}
+   */
+  create ({containerId, position, source, json, impressionTrackers, clickTrackers, viewabilityTrackers}) {
     return new Native({
       containerId: containerId,
       position: position,
@@ -18,6 +29,7 @@ export default class NativeFactory {
       json: json,
       impressionTrackers: impressionTrackers,
       clickTrackers: clickTrackers,
+      viewabilityTrackers: viewabilityTrackers,
       renderer: this._nativeRendererProcessor.getRenderer({position}),
       eventDispatcher: this._eventDispatcher
     })

--- a/src/openads/infrastructure/service/appnexus/AppNexusResultMapper.js
+++ b/src/openads/infrastructure/service/appnexus/AppNexusResultMapper.js
@@ -49,7 +49,8 @@ export default class AppNexusResultMapper {
           source: 'AppNexus',
           json: appNexusResponse.native,
           impressionTrackers: appNexusResponse.native.impressionTrackers,
-          clickTrackers: appNexusResponse.native.clickTrackers
+          clickTrackers: appNexusResponse.native.clickTrackers,
+          viewabilityTrackers: appNexusResponse.native.javascriptTrackers
         })
       }
       default: {

--- a/src/test/openads/domain/native/NativeRendererTest.js
+++ b/src/test/openads/domain/native/NativeRendererTest.js
@@ -76,12 +76,67 @@ describe('Native Renderer', () => {
       }).catch(e => done(e))
     })
   })
-  describe('Given valid containerId, json and impressionTrackings and providing clickTrackers', () => {
+  describe('Given valid containerId, json and viewabilityTrackers', () => {
+    it('Should call to the client render method and print the viewability trackings', (done) => {
+      const givenContainerId = 'test'
+      const givenJson = {a: 'json'}
+      const givenViewabilityTrackers = '<script></script>'
+
+      const createElementMock = (e) => {
+        let element = {
+          _appendedChildren: []
+        }
+        element.appendChild = (c) => element._appendedChildren.push(c)
+        element.getElementsByTagName = (t) => {
+          if (t === 'script') {
+            return [{src: ''}]
+          }
+          return []
+        }
+        return element
+      }
+      const container = createElementMock()
+      const domDriverMock = {
+        getElementById: ({id}) => {
+          return id === givenContainerId ? container : null
+        },
+        createElement: (e) => createElementMock(e)
+      }
+
+      const rendererMock = {
+        rendererFunction: ({json}) => {
+          return {
+            html: 'hello',
+            clickElementId: 'id'
+          }
+        }
+      }
+      const clientRendererFunctionSpy = sinon.spy(rendererMock, 'rendererFunction')
+
+      const nativeRenderer = new NativeRenderer({
+        clientRenderer: rendererMock.rendererFunction,
+        domDriver: domDriverMock
+      })
+
+      nativeRenderer.render({
+        containerId: givenContainerId,
+        json: givenJson,
+        viewabilityTrackers: givenViewabilityTrackers
+      }).then(() => {
+        expect(clientRendererFunctionSpy.calledOnce).to.be.true
+        expect(clientRendererFunctionSpy.getCall(0).args[0].json).to.deep.equal(givenJson)
+
+        expect(container._appendedChildren.length).to.equal(1)
+        expect(container._appendedChildren[0].src).to.not.undefined
+        done()
+      }).catch(e => done(e))
+    })
+  })
+  describe('Given valid containerId, json and providing clickTrackers', () => {
     it('Should register a method to the returned clickElementId that write clickTrackers to container if previous onclick was not defined on it', (done) => {
       const givenContainerId = 'test'
       const givenClickElementId = 'clickable'
       const givenJson = {a: 'json'}
-      const givenImpressionTrackers = ['url_i1', 'url_i2']
       const givenClickTrackers = ['url_t1', 'url_t2']
 
       const createElementMock = (e) => {
@@ -122,13 +177,12 @@ describe('Native Renderer', () => {
       nativeRenderer.render({
         containerId: givenContainerId,
         json: givenJson,
-        impressionTrackers: givenImpressionTrackers,
         clickTrackers: givenClickTrackers
       }).then(() => {
         expect(clickable.onclick).not.undefined
           // simulate user onclick
         clickable.onclick()
-        expect(container._appendedChildren.length).to.equal(givenImpressionTrackers.length + givenClickTrackers.length)
+        expect(container._appendedChildren.length).to.equal(givenClickTrackers.length)
         done()
       }).catch(e => done(e))
     })


### PR DESCRIPTION
This PR will:

* Add the viewability trackers in the NativeRenderer
* The viewability trackers are rendered into the Ad container after the impression trackers
* The viewability trackers (in AppNexus) are <scripts> tags into String content
