### PR TITLE
Add capability to enable ‘debug’ logger from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ const openAds = OpenAds.init({config: {
 }})
 ```
 
+Navigating in a browser, adding **openads_debug** to the URL's query string, will enable the debug mode automatically
+
 # Roadmap
 
 * Add support to Google AdSense

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       "integrity": "sha512-bdo0T1mQS5lRseuIxIRPoCj5cuOgvZlMybVqSLVCKaHL2PYjz2Iaai58ZHcC8OsMkv94wsWnYZJmtPv2BtxUFA=="
     },
     "@types/node": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.5.tgz",
-      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
+      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
       "dev": true
     },
     "abab": {
@@ -311,15 +311,15 @@
       "dev": true
     },
     "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "async": {
@@ -341,9 +341,9 @@
       "dev": true
     },
     "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
@@ -1411,12 +1411,12 @@
       "dev": true
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "2.16.3"
       }
     },
     "brace-expansion": {
@@ -1458,7 +1458,7 @@
       "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000787",
+        "caniuse-lite": "1.0.30000789",
         "electron-to-chromium": "1.3.30"
       }
     },
@@ -1501,9 +1501,9 @@
       "optional": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000787.tgz",
-      "integrity": "sha1-p2xPodasAGQER+yDwefGsz3WFcU=",
+      "version": "1.0.30000789",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000789.tgz",
+      "integrity": "sha1-Lj2TeyZxM/Y2Ne9/RB+sZjYPyIk=",
       "dev": true
     },
     "caseless": {
@@ -1529,7 +1529,7 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "check-error": "1.0.2",
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
@@ -1649,155 +1649,6 @@
         "argv": "0.0.2",
         "request": "2.81.0",
         "urlgrey": "0.4.4"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        }
       }
     },
     "color-convert": {
@@ -1895,23 +1746,12 @@
       }
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
+        "boom": "2.10.1"
       }
     },
     "css-select": {
@@ -1963,6 +1803,14 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "debug": {
@@ -2063,9 +1911,9 @@
       "dev": true
     },
     "doctrine": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -2352,7 +2200,7 @@
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.2",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.2",
@@ -2415,9 +2263,9 @@
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -2472,7 +2320,7 @@
         "contains-path": "0.1.0",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
+        "eslint-import-resolver-node": "0.3.2",
         "eslint-module-utils": "2.1.1",
         "has": "1.0.1",
         "lodash.cond": "4.5.2",
@@ -2533,7 +2381,7 @@
       "integrity": "sha512-YGSjB9Qu6QbVTroUZi66pYky3DfoIPLdHQ/wmrBGyBRnwxQsBXAov9j2rpXt/55i8nyMv6IRWJv2s4d4YnduzQ==",
       "dev": true,
       "requires": {
-        "doctrine": "2.0.2",
+        "doctrine": "2.1.0",
         "has": "1.0.1",
         "jsx-ast-utils": "2.0.1",
         "prop-types": "15.6.0"
@@ -2836,9 +2684,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
@@ -3831,6 +3679,14 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "glob": {
@@ -3987,19 +3843,31 @@
       }
     },
     "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
       "dev": true
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
       }
     },
     "has": {
@@ -4027,15 +3895,15 @@
       "dev": true
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       }
     },
     "he": {
@@ -4045,9 +3913,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "home-or-tmp": {
@@ -4088,7 +3956,7 @@
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.4"
+        "uglify-js": "3.3.5"
       }
     },
     "html-webpack-plugin": {
@@ -4167,12 +4035,12 @@
       }
     },
     "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "0.2.0",
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
@@ -4668,6 +4536,156 @@
         "whatwg-encoding": "1.0.3",
         "whatwg-url": "6.4.0",
         "xml-name-validator": "2.0.1"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "dev": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "dev": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "dev": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "request": {
+          "version": "2.83.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "jsesc": {
@@ -4752,6 +4770,14 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "jsx-ast-utils": {
@@ -5446,7 +5472,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.5"
+        "@types/node": "9.3.0"
       }
     },
     "path-exists": {
@@ -5509,9 +5535,9 @@
       "dev": true
     },
     "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
     "pify": {
@@ -5635,10 +5661,15 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
       "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -5950,28 +5981,28 @@
       }
     },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
+        "aws-sign2": "0.6.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.5",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
         "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
@@ -6490,12 +6521,12 @@
       }
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "2.16.3"
       }
     },
     "source-map": {
@@ -6571,6 +6602,14 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "stackframe": {
@@ -6789,9 +6828,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.4.tgz",
-      "integrity": "sha512-hfIwuAQI5dlXP30UtdmWoYF9k+ypVqBXIdmd6ZKBiaNHHvA8ty7ZloMe3+7S5AEKVkxHbjByl4DfRHQ7QpZquw==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.5.tgz",
+      "integrity": "sha512-ZebM2kgBL/UI9rKeAbsS2J0UPPv7SBy5hJNZml/YxB1zC6JK8IztcPs+cxilE4pu0li6vadVSFqiO7xFTKuSrg==",
       "dev": true,
       "requires": {
         "commander": "2.12.2",
@@ -6911,6 +6950,14 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@schibstedspain/ast": "^0.11.0",
     "loglevel": "^1.6.0",
-    "loglevel-plugin-prefix": "^0.5.3"
+    "loglevel-plugin-prefix": "^0.5.3",
+    "querystring": "^0.2.0"
   }
 }

--- a/src/openads/domain/logger/LoggerFactory.js
+++ b/src/openads/domain/logger/LoggerFactory.js
@@ -1,0 +1,8 @@
+/**
+ * @interface
+ */
+export default class LoggerFactory {
+  createLogger ({name}) {
+    throw new Error('LoggerFactory#createLogger must be implemented')
+  }
+}

--- a/src/openads/domain/service/ContextParametersService.js
+++ b/src/openads/domain/service/ContextParametersService.js
@@ -1,0 +1,8 @@
+/**
+ * @interface
+ */
+export default class ContextParametersService {
+  getContextParameters () {
+    throw new Error('ContextParametersService#getContextParameters must be implemented')
+  }
+}

--- a/src/openads/domain/service/DOMDriver.js
+++ b/src/openads/domain/service/DOMDriver.js
@@ -21,4 +21,8 @@ export default class DOMDriver {
   createElement ({tagName}) {
     throw new Error('DOMDriver#createElement must be implemented')
   }
+
+  getQueryString () {
+    throw new Error('DOMDriver#getQueryString must be implemented')
+  }
 }

--- a/src/openads/domain/service/LoggerInitializer.js
+++ b/src/openads/domain/service/LoggerInitializer.js
@@ -1,0 +1,16 @@
+import Logger from '../logger/Logger'
+
+export default class LoggerInitializer {
+  constructor ({logger, contextParametersService}) {
+    this._logger = logger
+    this._contextParametersService = contextParametersService
+    this._init()
+  }
+  _init () {
+    const contextParameters = this._contextParametersService.getContextParameters()
+    if (contextParameters.hasOwnProperty(OPENADS_DEBUG_KEY)) {
+      this._logger.setLevel(Logger.LEVELS.DEBUG)
+    }
+  }
+}
+const OPENADS_DEBUG_KEY = 'openads_debug'

--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -17,6 +17,8 @@ import AppNexusRequestMapper from '../service/appnexus/AppNexusRequestMapper'
 import LogLevel from 'loglevel'
 import LogLevelPrefix from 'loglevel-plugin-prefix'
 import LogLevelLoggerFactory from '../logger/LogLevelLoggerFactory'
+import LoggerInitializer from '../../domain/service/LoggerInitializer'
+import QueryStringContextParametersService from '../service/QueryStringContextParametersService'
 
 export default class Container {
   constructor ({config}) {
@@ -37,14 +39,27 @@ export default class Container {
   }
 
   _buildLogger () {
-    return this.getInstance({key: 'LogLevelLoggerFactory'}).createLogger({name: 'OpenAds'})
+    return this.getInstance({key: 'LoggerFactory'}).createLogger({name: 'OpenAds'})
   }
 
-  _buildLogLevelLoggerFactory () {
+  _buildLoggerFactory () {
     return new LogLevelLoggerFactory({
       logLevelInstance: LogLevel,
       logMessagePrefixInstance: LogLevelPrefix,
       loggerConfig: this._config.LogLevel
+    })
+  }
+
+  _buildLoggerInitializer () {
+    return new LoggerInitializer({
+      logger: this.getInstance({key: 'Logger'}),
+      contextParametersService: this.getInstance({key: 'ContextParametersService'})
+    })
+  }
+
+  _buildContextParametersService () {
+    return new QueryStringContextParametersService({
+      domDriver: this.getInstance({key: 'DOMDriver'})
     })
   }
 
@@ -153,6 +168,7 @@ export default class Container {
   }
 
   _buildEagerSingletonInstances () {
+    this.getInstance({key: 'LoggerInitializer'})
     this.getInstance({key: 'EventDispatcher'})
   }
 }

--- a/src/openads/infrastructure/logger/LogLevelLoggerFactory.js
+++ b/src/openads/infrastructure/logger/LogLevelLoggerFactory.js
@@ -1,7 +1,9 @@
 import LogLevelLogger from './LogLevelLogger'
+import LoggerFactory from '../../domain/logger/LoggerFactory'
 
-export default class LogLevelLoggerFactory {
+export default class LogLevelLoggerFactory extends LoggerFactory {
   constructor ({logLevelInstance, logMessagePrefixInstance, loggerConfig = {}} = {}) {
+    super()
     this._logLevelInstance = logLevelInstance
     this._logMessagePrefixInstance = logMessagePrefixInstance
     this._loggerConfig = loggerConfig

--- a/src/openads/infrastructure/service/HTMLDOMDriver.js
+++ b/src/openads/infrastructure/service/HTMLDOMDriver.js
@@ -28,4 +28,8 @@ export default class HTMLDOMDriver extends DOMDriver {
   createElement ({tagName}) {
     return this._dom.createElement(tagName)
   }
+
+  getQueryString () {
+    return this._dom.location.search.slice(1)
+  }
 }

--- a/src/openads/infrastructure/service/QueryStringContextParametersService.js
+++ b/src/openads/infrastructure/service/QueryStringContextParametersService.js
@@ -1,0 +1,13 @@
+import QS from 'querystring'
+import ContextParametersService from '../../domain/service/ContextParametersService'
+
+export default class QueryStringContextParametersService extends ContextParametersService {
+  constructor ({domDriver}) {
+    super()
+    this._domDriver = domDriver
+  }
+  getContextParameters () {
+    const queryStringStr = this._domDriver.getQueryString()
+    return QS.parse(queryStringStr)
+  }
+}

--- a/src/test/openads/domain/logger/LoggerFactoryTest.js
+++ b/src/test/openads/domain/logger/LoggerFactoryTest.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-unused-expressions */
+import {expect} from 'chai'
+import LoggerFactory from '../../../../openads/domain/logger/LoggerFactory'
+
+describe('LoggerFactory', function () {
+  it('Should return an error calling a non extended method #createLogger', function () {
+    const loggerFactory = new LoggerFactory()
+    expect(() => {
+      loggerFactory.createLogger({name: 'whatever'})
+    }).to.throw()
+  })
+})

--- a/src/test/openads/domain/service/ContextParametersServiceTest.js
+++ b/src/test/openads/domain/service/ContextParametersServiceTest.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-unused-expressions */
+import {expect} from 'chai'
+import ContextParametersService from '../../../../openads/domain/service/ContextParametersService'
+
+describe('ContextParametersService', () => {
+  it('Should return an error calling a non extended method #getContextParameters', function () {
+    const contextParametersService = new ContextParametersService()
+    expect(() => {
+      contextParametersService.getContextParameters()
+    }).to.throw()
+  })
+})

--- a/src/test/openads/domain/service/DOMDriverTest.js
+++ b/src/test/openads/domain/service/DOMDriverTest.js
@@ -33,4 +33,10 @@ describe('DOMDriver', () => {
       givenDOMDriver.createElement({})
     }).to.throw()
   })
+  it('Should return an error calling to DOMDriver#getQueryString instead of a extending class implementation', () => {
+    const givenDOMDriver = new DOMDriver()
+    expect(() => {
+      givenDOMDriver.getQueryString()
+    }).to.throw()
+  })
 })

--- a/src/test/openads/domain/service/LoggerInitializerTest.js
+++ b/src/test/openads/domain/service/LoggerInitializerTest.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-unused-expressions */
+import {expect} from 'chai'
+import sinon from 'sinon'
+import LoggerInitializer from '../../../../openads/domain/service/LoggerInitializer'
+
+describe('LoggerInitializer', function () {
+  describe('Given context parameters without the openads_debug key', function () {
+    const givenContextParameters = {'a': 'b'}
+    it('Should do not change the logger level', function () {
+      const loggerMock = {
+        setLevel: (level) => null
+      }
+      const contextParametersServiceMock = {
+        getContextParameters: () => givenContextParameters
+      }
+      const getContextParametersSpy = sinon.spy(contextParametersServiceMock, 'getContextParameters')
+      const setLevelSpy = sinon.spy(loggerMock, 'setLevel')
+
+      expect(() => new LoggerInitializer({
+        logger: loggerMock,
+        contextParametersService: contextParametersServiceMock
+      })).to.not.throw()
+
+      expect(getContextParametersSpy.calledOnce).to.be.true
+      expect(setLevelSpy.notCalled).to.be.true
+    })
+  })
+  describe('Given context parameters with the openads_debug key', function () {
+    const givenContextParameters = {'openads_debug': ''}
+    it('Should change the logger level to debug', function () {
+      const loggerMock = {
+        setLevel: (level) => null
+      }
+      const contextParametersServiceMock = {
+        getContextParameters: () => givenContextParameters
+      }
+      const getContextParametersSpy = sinon.spy(contextParametersServiceMock, 'getContextParameters')
+      const setLevelSpy = sinon.spy(loggerMock, 'setLevel')
+
+      expect(() => new LoggerInitializer({
+        logger: loggerMock,
+        contextParametersService: contextParametersServiceMock
+      })).to.not.throw()
+
+      expect(getContextParametersSpy.calledOnce).to.be.true
+      expect(setLevelSpy.calledOnce).to.be.true
+      expect(setLevelSpy.args[0][0]).to.equal('debug')
+    })
+  })
+})

--- a/src/test/openads/infrastructure/service/HTMLDOMDriverTest.js
+++ b/src/test/openads/infrastructure/service/HTMLDOMDriverTest.js
@@ -132,4 +132,24 @@ describe('DOM Driver HTML simple implementation', function () {
 
     expect(createElementSpy.called).to.be.true
   })
+  it('Should return the query string if it exists, without the ? separator', () => {
+    const givenDocumentMock = {
+      location: {
+        search: '?a=b&c=d&e'
+      }
+    }
+    const htmlDOMDriver = new HTMLDOMDriver({dom: givenDocumentMock})
+    const queryString = htmlDOMDriver.getQueryString()
+    expect(queryString).to.equal('a=b&c=d&e')
+  })
+  it('Should return empty query string if it does not exist in dom\'s location', () => {
+    const givenDocumentMock = {
+      location: {
+        search: ''
+      }
+    }
+    const htmlDOMDriver = new HTMLDOMDriver({dom: givenDocumentMock})
+    const queryString = htmlDOMDriver.getQueryString()
+    expect(queryString).to.equal('')
+  })
 })

--- a/src/test/openads/infrastructure/service/QueryStringContextParametersServiceTest.js
+++ b/src/test/openads/infrastructure/service/QueryStringContextParametersServiceTest.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-unused-expressions */
+import {expect} from 'chai'
+import QueryStringContextParametersService from '../../../../openads/infrastructure/service/QueryStringContextParametersService'
+
+describe('QueryString ContextParametersService', function () {
+  describe('Given a valid query string', function () {
+    it('Return an object containing the parsed key/value pairs', function () {
+      const givenQueryString = 'a=b&c=d&e'
+      const domDriverMock = {
+        getQueryString: () => givenQueryString
+      }
+      const contextParametersService = new QueryStringContextParametersService({domDriver: domDriverMock})
+      const contextParameters = contextParametersService.getContextParameters()
+
+      expect(contextParameters).to.deep.equal({
+        'a': 'b',
+        'c': 'd',
+        'e': ''
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR will: Add capability to enable ‘debug’ logger from url
* Parses the URL’s query string and if the ‘openads_debug’ key is found, the debug mode is enabled
* README update with the capability
* Adds the ‘querystring’ library dependency (lightweight query string parser)