### PR TITLE
Hotfix/invalid package name for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It helps you to show ads in a easy way using simple use cases and work with sour
 OpenAds is available as the ```@schibstedspain/OpenAds``` package on [npm](https://www.npmjs.com/)
 To install the stable version:
 ```
-npm install --save @schibstedspain/OpenAds
+npm install --save @schibstedspain/open-ads
 ```
 
 # Usage
@@ -17,7 +17,7 @@ First of all you must include OpenAds and **initialize it** with your desired co
 Currently we only support AppNexus Source so you can only provide your **member** number
 
 ```ecmascript 6
-import OpenAds from '@schibstedspain/OpenAds'
+import OpenAds from '@schibstedspain/open-ads'
 const openAds = OpenAds.init({config:{
   Sources: {
     AppNexus: {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It helps you to show ads in a easy way using simple use cases and work with sour
 OpenAds is available as the ```@schibstedspain/OpenAds``` package on [npm](https://www.npmjs.com/)
 To install the stable version:
 ```
-npm install --save @schibstedspain/open-ads
+npm install --save @schibstedspain/openads
 ```
 
 # Usage
@@ -17,7 +17,7 @@ First of all you must include OpenAds and **initialize it** with your desired co
 Currently we only support AppNexus Source so you can only provide your **member** number
 
 ```ecmascript 6
-import OpenAds from '@schibstedspain/open-ads'
+import OpenAds from '@schibstedspain/openads'
 const openAds = OpenAds.init({config:{
   Sources: {
     AppNexus: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/open-ads",
+  "name": "@schibstedspain/openads",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@schibstedspain/OpenAds",
-  "version": "0.0.1",
+  "name": "@schibstedspain/open-ads",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/open-ads",
+  "name": "@schibstedspain/openads",
   "version": "1.0.0",
   "description": "OpenAds: Advertising library",
   "main": "dist/",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/OpenAds",
+  "name": "@schibstedspain/open-ads",
   "version": "1.0.0",
   "description": "OpenAds: Advertising library",
   "main": "dist/",


### PR DESCRIPTION
The publish to NPM failed:

40 verbose argv "/usr/local/bin/node" "/usr/local/bin/npm" "publish"
41 verbose node v6.5.0
42 verbose npm  v5.6.0
43 error code E400
44 error "@schibstedspain/OpenAds" is invalid for new packages : @schibstedspain/OpenAds

According to [https://github.com/npm/npm/issues/15787](https://github.com/npm/npm/issues/15787):
we have to change the package name.

![](https://media.giphy.com/media/AQNuLMbseYPks/giphy.gif)