### PR TITLE
Add adError event evaluation in appnexus connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenAds: Advertising library",
   "main": "dist/",
   "scripts": {

--- a/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
+++ b/src/openads/infrastructure/repository/appnexus/AppNexusAdRepository.js
@@ -37,6 +37,13 @@ export default class AppNexusAdRepository extends AdRepository {
             reject(data)
           }
         })
+        .onEvent({
+          event: 'adError',
+          targetId: adRequest.containerId,
+          callback: (data) => {
+            reject(data)
+          }
+        })
         .defineTag(this._appNexusRequestMapper.mapDomainToRequest({
           member: this._connector.member,
           targetId: adRequest.containerId,

--- a/src/test/openads/infrastructure/repository/appnexus/AppNexusAdRepositoryTest.js
+++ b/src/test/openads/infrastructure/repository/appnexus/AppNexusAdRepositoryTest.js
@@ -64,7 +64,10 @@ describe('AppNexus repository', function () {
         adRequest: givenAdRequest
       })
         .then(ad => {
-          expect(this.onEventSpy.calledTwice, 'onEvent not called twice').to.be.true
+          expect(this.onEventSpy.callCount, 'onEvent has not registered all events').to.equal(3)
+          expect(this.onEventSpy.args[0][0]['event'], 'adAvailable not registered').to.equal('adAvailable')
+          expect(this.onEventSpy.args[1][0]['event'], 'adBadRequest not registered').to.equal('adBadRequest')
+          expect(this.onEventSpy.args[2][0]['event'], 'adError not registered').to.equal('adError')
           expect(this.defineTagSpy.calledOnce, 'defineTag not called once').to.be.true
           expect(this.loadTagsSpy.calledOnce, 'loadTags not called once').to.be.true
           expect(this.mapResponseToDomainSpy.calledOnce, 'mapResponseToDomain not called once').to.be.true

--- a/src/test/openads/infrastructure/repository/appnexus/AppNexusAdRepositoryTest.js
+++ b/src/test/openads/infrastructure/repository/appnexus/AppNexusAdRepositoryTest.js
@@ -103,6 +103,33 @@ describe('AppNexus repository', function () {
         .then(ad => done(new Error('Promise should resolve as rejected')))
         .catch(() => done())
     })
+
+    it('should return a rejected Promise when someone call to callback on adError event', function (done) {
+      const givenAdRequest = {}
+
+      this.appNexusConnectorMock = {
+        activateDebugMode: () => this.appNexusConnectorMock,
+        setPageOpts: ({data}) => this.appNexusConnectorMock,
+        onEvent: ({event, targetId, callback}) => {
+          if (event === 'adError') callback(new Error('error'))
+          return this.appNexusConnectorMock
+        },
+        defineTag: ({data}) => this.appNexusConnectorMock,
+        loadTags: () => this.appNexusConnectorMock
+      }
+
+      const appnexusRepository = new AppNexusAdRepository({
+        appNexusConnector: this.appNexusConnectorMock,
+        appNexusResultMapper: this.appNexusResultMapperMock,
+        appNexusRequestMapper: this.appNexusRequestMapperMock
+      })
+
+      appnexusRepository.findAd({
+        adRequest: givenAdRequest
+      })
+        .then(ad => done(new Error('Promise should resolve as rejected')))
+        .catch(() => done())
+    })
   })
 
   describe('Calling the reset method', function () {


### PR DESCRIPTION
* this enables the Promise rejection when the Ad is not loaded by any previous problem

![](https://media.giphy.com/media/1RkDDoIVs3ntm/giphy.gif)