### PR TITLE
New DomainEventBus class to manage events.

### DIFF
--- a/src/openads/domain/service/DomainEventBus.js
+++ b/src/openads/domain/service/DomainEventBus.js
@@ -1,0 +1,45 @@
+class DomainEventBus {
+  constructor () {
+    this._observers = new Map()
+  }
+
+  register ({eventName, observer}) {
+    if (!eventName) {
+      throw new Error('Event Name is required')
+    }
+    if (typeof observer !== 'function') {
+      throw new Error('Observer must be a function')
+    }
+    if (!this._observers.has(eventName)) {
+      this._observers.set(eventName, [observer])
+    } else {
+      this._observers.get(eventName).push(observer)
+    }
+  }
+
+  raise ({domainEvent}) {
+    this._observers
+      .get(domainEvent.eventName)
+      .forEach(observer => {
+        try {
+          observer({
+            payload: domainEvent.payload,
+            dispatcher: (data) => this.raise({domainEvent: data})
+          })
+        } catch (err) {
+          console.log('Error processing the observer: ', err)
+        }
+      })
+  }
+
+  getObservers () {
+    return this._observers
+  }
+
+  clearAllObservers () {
+    this._observers.clear()
+  }
+}
+
+const domainEventBus = new DomainEventBus()
+export default domainEventBus

--- a/src/openads/domain/service/DomainEventBus.js
+++ b/src/openads/domain/service/DomainEventBus.js
@@ -27,7 +27,14 @@ class DomainEventBus {
             dispatcher: (data) => this.raise({domainEvent: data})
           })
         } catch (err) {
-          console.log('Error processing the observer: ', err)
+          const domainEvent = {
+            eventName: ERROR_EVENT,
+            payload: {
+              message: 'Error processing the observer.',
+              error: err
+            }
+          }
+          this.raise({domainEvent})
         }
       })
   }
@@ -48,6 +55,6 @@ class DomainEventBus {
     this._observers.clear()
   }
 }
-
+const ERROR_EVENT = 'ERROR_EVENT'
 const domainEventBus = new DomainEventBus()
 export default domainEventBus

--- a/src/openads/domain/service/DomainEventBus.js
+++ b/src/openads/domain/service/DomainEventBus.js
@@ -32,8 +32,16 @@ class DomainEventBus {
       })
   }
 
-  getObservers () {
-    return this._observers
+  getNumberOfRegisteredEvents () {
+    return this._observers.size
+  }
+
+  getNumberOfObserversRegisteredForAnEvent ({eventName}) {
+    let result = 0
+    if (this._observers.get(eventName)) {
+      result = this._observers.get(eventName).length
+    }
+    return result
   }
 
   clearAllObservers () {

--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -9,6 +9,7 @@ import AppNexusBannerRenderer from '../service/appnexus/AppNexusBannerRenderer'
 import FindAdUseCase from '../../application/service/FindAdUseCase'
 import AppNexusClient from '../connector/appnexus/AppNexusClient'
 import EventDispatcher from '../../domain/service/EventDispatcher'
+import DomainEventBus from '../../domain/service/DomainEventBus'
 import ResetConnectorsUseCase from '../../application/service/ResetConnectorsUseCase'
 import NativeRendererFactory from '../../domain/ad/native/NativeRendererFactory'
 import NativeRendererProcessor from '../../domain/service/NativeRendererProcessor'
@@ -19,6 +20,7 @@ import LogLevelPrefix from 'loglevel-plugin-prefix'
 import LogLevelLoggerInitializer from '../logger/LogLevelLoggerInitializer'
 import LogLevelPrefixConfigurator from '../logger/LogLevelPrefixConfigurator'
 import LogLevelConfigurator from '../logger/LogLevelConfigurator'
+import {errorObserverFactory} from 'errorObserverFactory'
 
 export default class Container {
   constructor ({config}) {
@@ -170,7 +172,17 @@ export default class Container {
     })
   }
 
+  _buildErrorObserverFactory () {
+    const logger = this.getInstance({key: 'Logger'})
+    return errorObserverFactory(logger)
+  }
+
   _buildEagerSingletonInstances () {
     this.getInstance({key: 'EventDispatcher'})
+    const errorObserver = this.getInstance({key: 'ErrorObserverFactory'})
+    DomainEventBus.register({
+      eventName: ERROR_EVENT,
+      observer: errorObserver})
   }
 }
+const ERROR_EVENT = 'ERROR_EVENT'

--- a/src/openads/infrastructure/configuration/errorObserverFactory.js
+++ b/src/openads/infrastructure/configuration/errorObserverFactory.js
@@ -1,0 +1,1 @@
+export const errorObserverFactory = logger => payload => logger.error('ERROR_EVENT', payload)

--- a/src/test/openads/domain/service/DomainEventBusTest.js
+++ b/src/test/openads/domain/service/DomainEventBusTest.js
@@ -21,6 +21,17 @@ describe('DomainEventBus test', () => {
         done()
       }
     })
+    it('Should return 0 when calling getNumberOfRegisteredEvents if there is no events registered', (done) => {
+      const result = DomainEventBus.getNumberOfRegisteredEvents()
+      expect(0).equal(result)
+      done()
+    })
+    it('Should return 0 when calling getNumberOfObserversRegisteredForAnEvent if there is no events registered', (done) => {
+      const givenEventName = 'nonExistingEvent'
+      const result = DomainEventBus.getNumberOfObserversRegisteredForAnEvent({eventName: givenEventName})
+      expect(0).equal(result)
+      done()
+    })
   })
   describe('Given a registered DomainEventBus', () => {
     let observerSpy = sinon.spy()
@@ -39,7 +50,7 @@ describe('DomainEventBus test', () => {
 
       expect(observerSpy.calledOnce).equal(true)
       expect(observerSpy.lastCall.args[0].payload).equal(domainEvent.payload)
-      expect(DomainEventBus.getObservers().size).equal(1)
+      expect(DomainEventBus.getNumberOfRegisteredEvents()).equal(1)
 
       const domainEventBusTestHelper = new DomainEventBusWrapper()
       const givenEventName2 = 'givenEventName2'
@@ -52,12 +63,12 @@ describe('DomainEventBus test', () => {
 
       expect(observerSpy.calledTwice).equal(true)
       expect(observerSpy.lastCall.args[0].payload).equal(domainEvent2.payload)
-      expect(DomainEventBus.getObservers().size).equal(2)
+      expect(DomainEventBus.getNumberOfRegisteredEvents()).equal(2)
       done()
     })
     it('Should clear all observers', (done) => {
       DomainEventBus.clearAllObservers()
-      expect(DomainEventBus.getObservers().size).equal(0)
+      expect(DomainEventBus.getNumberOfRegisteredEvents()).equal(0)
       done()
     })
     it('Should execute all observers related to an event', (done) => {
@@ -74,8 +85,8 @@ describe('DomainEventBus test', () => {
       expect(observerSpy.getCalls().length).equal(2)
       expect(observerSpy.getCall(0).args[0].payload).equal(domainEvent.payload)
       expect(observerSpy.getCall(1).args[0].payload).equal(domainEvent.payload)
-      expect(DomainEventBus.getObservers().size).equal(1)
-      expect(DomainEventBus.getObservers().get(givenEventName).length).equal(2)
+      expect(DomainEventBus.getNumberOfRegisteredEvents()).equal(1)
+      expect(DomainEventBus.getNumberOfObserversRegisteredForAnEvent({eventName: givenEventName})).equal(2)
       done()
     })
   })
@@ -107,8 +118,7 @@ describe('DomainEventBus test', () => {
       DomainEventBus.register({eventName: givenEvent1Name, observer: observer1.getObserverFunction})
       DomainEventBus.register({eventName: givenEvent2Name, observer: observer2.getObserverFunction})
       DomainEventBus.raise({domainEvent: event1DomainEvent})
-
-      expect(DomainEventBus.getObservers().size).equal(2)
+      expect(DomainEventBus.getNumberOfRegisteredEvents()).equal(2)
       expect(spy1.calledOnce).equal(true)
       expect(spy1.getCall(0).args[0].payload).equal(event1DomainEvent.payload)
       expect(spy1.getCall(0).args[0].dispatcher).is.a('function')
@@ -144,8 +154,8 @@ describe('DomainEventBus test', () => {
       DomainEventBus.register({eventName: givenEvent1Name, observer: observer2.getObserverFunction})
       DomainEventBus.raise({domainEvent: event1DomainEvent})
 
-      expect(DomainEventBus.getObservers().size).equal(1)
-      expect(DomainEventBus.getObservers().get(givenEvent1Name).length).equal(2)
+      expect(DomainEventBus.getNumberOfRegisteredEvents()).equal(1)
+      expect(DomainEventBus.getNumberOfObserversRegisteredForAnEvent({eventName: givenEvent1Name})).equal(2)
       expect(spy1.calledOnce).equal(true)
       expect(spy2.calledOnce).equal(true)
       done()

--- a/src/test/openads/domain/service/DomainEventBusTest.js
+++ b/src/test/openads/domain/service/DomainEventBusTest.js
@@ -1,0 +1,154 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+import DomainEventBus from '../../../../openads/domain/service/DomainEventBus'
+import DomainEventBusWrapper from './helper/DomainEventBusWrapper'
+
+describe('DomainEventBus test', () => {
+  describe('Given invalid register parameters', () => {
+    it('Should fail if eventName is not present', (done) => {
+      try {
+        DomainEventBus.register({eventName: undefined, observer: undefined})
+        done(new Error('Should fail'))
+      } catch (error) {
+        done()
+      }
+    })
+    it('Should fail if observer is not a function', (done) => {
+      try {
+        DomainEventBus.register({eventName: 'givenEvent', observer: undefined})
+        done(new Error('Should fail'))
+      } catch (error) {
+        done()
+      }
+    })
+  })
+  describe('Given a registered DomainEventBus', () => {
+    let observerSpy = sinon.spy()
+    beforeEach(function () {
+      observerSpy.reset()
+    })
+    it('Should execute observer callback using the raised payload', (done) => {
+      const givenEventName = 'givenEventName'
+      const domainEvent = {
+        eventName: givenEventName,
+        payload: 'domainEvent payload'
+      }
+      DomainEventBus.clearAllObservers()
+      DomainEventBus.register({eventName: givenEventName, observer: observerSpy})
+      DomainEventBus.raise({domainEvent})
+
+      expect(observerSpy.calledOnce).equal(true)
+      expect(observerSpy.lastCall.args[0].payload).equal(domainEvent.payload)
+      expect(DomainEventBus.getObservers().size).equal(1)
+
+      const domainEventBusTestHelper = new DomainEventBusWrapper()
+      const givenEventName2 = 'givenEventName2'
+      const domainEvent2 = {
+        eventName: givenEventName2,
+        payload: 'domainEvent 2 payload'
+      }
+      domainEventBusTestHelper.register({eventName: givenEventName2, observer: observerSpy})
+      domainEventBusTestHelper.raise({domainEvent: domainEvent2})
+
+      expect(observerSpy.calledTwice).equal(true)
+      expect(observerSpy.lastCall.args[0].payload).equal(domainEvent2.payload)
+      expect(DomainEventBus.getObservers().size).equal(2)
+      done()
+    })
+    it('Should clear all observers', (done) => {
+      DomainEventBus.clearAllObservers()
+      expect(DomainEventBus.getObservers().size).equal(0)
+      done()
+    })
+    it('Should execute all observers related to an event', (done) => {
+      const givenEventName = 'givenEventName'
+      const domainEvent = {
+        eventName: givenEventName,
+        payload: '1'
+      }
+
+      DomainEventBus.clearAllObservers()
+      DomainEventBus.register({eventName: givenEventName, observer: observerSpy})
+      DomainEventBus.register({eventName: givenEventName, observer: observerSpy})
+      DomainEventBus.raise({domainEvent: domainEvent})
+      expect(observerSpy.getCalls().length).equal(2)
+      expect(observerSpy.getCall(0).args[0].payload).equal(domainEvent.payload)
+      expect(observerSpy.getCall(1).args[0].payload).equal(domainEvent.payload)
+      expect(DomainEventBus.getObservers().size).equal(1)
+      expect(DomainEventBus.getObservers().get(givenEventName).length).equal(2)
+      done()
+    })
+  })
+  describe('Given 1 event with 1 subscriber which has a dispatcher to raise a second event with another subscriber', () => {
+    it('Should be raised event 2 by subscriber 1 when event 1 is raised', (done) => {
+      const givenEvent1Name = 'event-1'
+      const event1DomainEvent = {
+        eventName: givenEvent1Name,
+        payload: 'event-1-payload'
+      }
+      const givenEvent2Name = 'event-2'
+      const event2DomainEvent = {
+        eventName: givenEvent2Name,
+        payload: 'event-2-payload'
+      }
+      const observer1 = {
+        getObserverFunction: ({payload, dispatcher}) => {
+          dispatcher(event2DomainEvent)
+        }
+      }
+      const observer2 = {
+        getObserverFunction: ({payload, dispatcher}) => {
+        }
+      }
+      const spy1 = sinon.spy(observer1, 'getObserverFunction')
+      const spy2 = sinon.spy(observer2, 'getObserverFunction')
+
+      DomainEventBus.clearAllObservers()
+      DomainEventBus.register({eventName: givenEvent1Name, observer: observer1.getObserverFunction})
+      DomainEventBus.register({eventName: givenEvent2Name, observer: observer2.getObserverFunction})
+      DomainEventBus.raise({domainEvent: event1DomainEvent})
+
+      expect(DomainEventBus.getObservers().size).equal(2)
+      expect(spy1.calledOnce).equal(true)
+      expect(spy1.getCall(0).args[0].payload).equal(event1DomainEvent.payload)
+      expect(spy1.getCall(0).args[0].dispatcher).is.a('function')
+      expect(spy2.calledOnce).equal(true)
+      expect(spy2.getCall(0).args[0].payload).equal(event2DomainEvent.payload)
+      expect(spy2.getCall(0).args[0].dispatcher).is.a('function')
+      done()
+    })
+  })
+  describe('Given 1 event with 2 subscribers, one of them causing an error', () => {
+    it('Should execute the non failing subscriber smoothly', (done) => {
+      const givenEvent1Name = 'event-1'
+      const event1DomainEvent = {
+        eventName: givenEvent1Name,
+        payload: 'event-1-payload'
+      }
+      const observer1 = {
+        getObserverFunction: ({payload, dispatcher}) => {
+          // observer1 will fail
+          throw new Error('expected error')
+        }
+      }
+      const observer2 = {
+        getObserverFunction: ({payload, dispatcher}) => {
+          // observer2 will work
+        }
+      }
+      const spy1 = sinon.spy(observer1, 'getObserverFunction')
+      const spy2 = sinon.spy(observer2, 'getObserverFunction')
+
+      DomainEventBus.clearAllObservers()
+      DomainEventBus.register({eventName: givenEvent1Name, observer: observer1.getObserverFunction})
+      DomainEventBus.register({eventName: givenEvent1Name, observer: observer2.getObserverFunction})
+      DomainEventBus.raise({domainEvent: event1DomainEvent})
+
+      expect(DomainEventBus.getObservers().size).equal(1)
+      expect(DomainEventBus.getObservers().get(givenEvent1Name).length).equal(2)
+      expect(spy1.calledOnce).equal(true)
+      expect(spy2.calledOnce).equal(true)
+      done()
+    })
+  })
+})

--- a/src/test/openads/domain/service/DomainEventBusTest.js
+++ b/src/test/openads/domain/service/DomainEventBusTest.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-alert, no-console */
+
 import {expect} from 'chai'
 import sinon from 'sinon'
 import DomainEventBus from '../../../../openads/domain/service/DomainEventBus'
@@ -129,7 +131,7 @@ describe('DomainEventBus test', () => {
     })
   })
   describe('Given 1 event with 2 subscribers, one of them causing an error', () => {
-    it('Should execute the non failing subscriber smoothly', (done) => {
+    it('Should execute the non failing subscriber smoothly and log the error', (done) => {
       const givenEvent1Name = 'event-1'
       const event1DomainEvent = {
         eventName: givenEvent1Name,
@@ -150,11 +152,16 @@ describe('DomainEventBus test', () => {
       const spy2 = sinon.spy(observer2, 'getObserverFunction')
 
       DomainEventBus.clearAllObservers()
+      const errorObserver = (payload) => { console.log('ERROR_EVENT TEST: ', payload) }
+      DomainEventBus.register({
+        eventName: 'ERROR_EVENT',
+        observer: errorObserver})
+
       DomainEventBus.register({eventName: givenEvent1Name, observer: observer1.getObserverFunction})
       DomainEventBus.register({eventName: givenEvent1Name, observer: observer2.getObserverFunction})
       DomainEventBus.raise({domainEvent: event1DomainEvent})
 
-      expect(DomainEventBus.getNumberOfRegisteredEvents()).equal(1)
+      expect(DomainEventBus.getNumberOfRegisteredEvents()).equal(2)
       expect(DomainEventBus.getNumberOfObserversRegisteredForAnEvent({eventName: givenEvent1Name})).equal(2)
       expect(spy1.calledOnce).equal(true)
       expect(spy2.calledOnce).equal(true)

--- a/src/test/openads/domain/service/helper/DomainEventBusWrapper.js
+++ b/src/test/openads/domain/service/helper/DomainEventBusWrapper.js
@@ -1,0 +1,11 @@
+import DomainEventBus from '../../../../../openads/domain/service/DomainEventBus'
+
+export default class DomainEventBusWrapper {
+  register ({eventName, observer}) {
+    DomainEventBus.register({eventName, observer})
+  }
+
+  raise ({domainEvent}) {
+    DomainEventBus.raise({domainEvent})
+  }
+}

--- a/src/test/openads/infrastructure/configuration/errorObserverFactoryTest.js
+++ b/src/test/openads/infrastructure/configuration/errorObserverFactoryTest.js
@@ -1,0 +1,26 @@
+import {errorObserverFactory} from '../../../../openads/infrastructure/configuration/errorObserverFactory'
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+describe('errorObserverFactory test', () => {
+  describe('Given a fake logger', () => {
+    it('Should use this logger calling error method with expected parameters', () => {
+      const givenLogger = {
+        error: (p1, p2) => {}
+      }
+      const loggerSpy = sinon.spy(givenLogger, 'error')
+      const givenPayload = {
+        message: 'Error processing the observer.',
+        error: 'err'
+      }
+      const givenErrorEventMessage = 'ERROR_EVENT'
+
+      const observer = errorObserverFactory(givenLogger)
+      observer(givenPayload)
+
+      expect(loggerSpy.calledOnce).equal(true)
+      expect(loggerSpy.getCall(0).args[0]).equal(givenErrorEventMessage)
+      expect(loggerSpy.getCall(0).args[1]).equal(givenPayload)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a new DomainEventBus class to manage events that will replace current EventDispatcher approach when we develop discussed openAds 2 use cases approach.