### PR TITLE
Prepare display position use case to manage native ads requests:

### DIFF
--- a/src/openads/domain/position/PositionAdIsNativeError.js
+++ b/src/openads/domain/position/PositionAdIsNativeError.js
@@ -1,0 +1,8 @@
+export default class PositionAdIsNativeError extends Error {
+  constructor ({id}) {
+    super()
+    this.name = 'PositionAdIsNativeError'
+    this.message = `Position ${id} AD is Native.`
+    this.stack = (new Error()).stack
+  }
+}

--- a/src/openads/domain/position/PositionAdNotAvailableError.js
+++ b/src/openads/domain/position/PositionAdNotAvailableError.js
@@ -1,0 +1,8 @@
+export default class PositionAdNotAvailableError extends Error {
+  constructor ({id}) {
+    super()
+    this.name = 'PositionAdNotAvailableError'
+    this.message = `Position ${id} AD not available.`
+    this.stack = (new Error()).stack
+  }
+}

--- a/src/test/openads/application/service/DisplayPositionUseCaseTest.js
+++ b/src/test/openads/application/service/DisplayPositionUseCaseTest.js
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import DisplayPositionUseCase from '../../../../openads/application/service/DisplayPositionUseCase'
 import {POSITION_NOT_VISIBLE, POSITION_VISIBLE} from '../../../../openads/domain/position/positionStatus'
 import Position from '../../../../openads/domain/position/Position'
+import {AD_AVAILABLE, AD_NO_BID} from '../../../../openads/infrastructure/connector/appnexus/event/events'
 
 describe('DisplayPositionUseCase test', () => {
   describe('display method test', () => {
@@ -20,11 +21,18 @@ describe('DisplayPositionUseCase test', () => {
       })
     })
     describe('Given an existing position', () => {
-      it('Should save the position with the new state', (done) => {
+      it('Should save the position with the new state when AD has AD_AVAILABLE status', (done) => {
         const givenIdPosition = 1
+        const givenAd = {
+          status: AD_AVAILABLE,
+          data: {
+            adType: 'banner'
+          }
+        }
         const givenPosition = new Position({
           id: givenIdPosition,
-          status: POSITION_NOT_VISIBLE
+          status: POSITION_NOT_VISIBLE,
+          ad: Promise.resolve(givenAd)
         })
         const positionRepositoryMock = {
           find: () => Promise.resolve(givenPosition),
@@ -34,6 +42,57 @@ describe('DisplayPositionUseCase test', () => {
         displayPositionUseCase.displayPosition({id: givenIdPosition})
           .then((position) => {
             expect(position.status).equal(POSITION_VISIBLE)
+            done()
+          })
+      })
+      it('Should reject when the position has an AD with status not equal to AD_AVAILABLE', (done) => {
+        const givenIdPosition = 1
+        const givenAd = {
+          status: AD_NO_BID
+        }
+        const givenPosition = new Position({
+          id: givenIdPosition,
+          status: POSITION_NOT_VISIBLE,
+          ad: Promise.resolve(givenAd)
+        })
+        const positionRepositoryMock = {
+          find: () => Promise.resolve(givenPosition),
+          saveOrUpdate: ({position}) => Promise.resolve(position)
+        }
+        const displayPositionUseCase = new DisplayPositionUseCase({positionRepository: positionRepositoryMock})
+        displayPositionUseCase.displayPosition({id: givenIdPosition})
+          .then(() => {
+            done(new Error('Should be failing'))
+          })
+          .catch(err => {
+            expect(err.name).equal('PositionAdNotAvailableError')
+            done()
+          })
+      })
+      it('Should reject when the position has an AD with status not equal to AD_AVAILABLE', (done) => {
+        const givenIdPosition = 1
+        const givenAd = {
+          status: AD_AVAILABLE,
+          data: {
+            adType: 'native'
+          }
+        }
+        const givenPosition = new Position({
+          id: givenIdPosition,
+          status: POSITION_NOT_VISIBLE,
+          ad: Promise.resolve(givenAd)
+        })
+        const positionRepositoryMock = {
+          find: () => Promise.resolve(givenPosition),
+          saveOrUpdate: ({position}) => Promise.resolve(position)
+        }
+        const displayPositionUseCase = new DisplayPositionUseCase({positionRepository: positionRepositoryMock})
+        displayPositionUseCase.displayPosition({id: givenIdPosition})
+          .then(() => {
+            done(new Error('Should be failing'))
+          })
+          .catch(err => {
+            expect(err.name).equal('PositionAdIsNativeError')
             done()
           })
       })


### PR DESCRIPTION
* Reject requests when position Ad is not available
* Reject requests when position Ad is native
* Added 2 new custom errors: PositionAdIsNativeError and PositionAdNotAvailableError