### PR TITLE
Hotfix/add modifytag method

### DIFF
--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -152,7 +152,6 @@ export default class Container {
   }
 
   _buildEagerSingletonInstances () {
-    this.getInstance({key: 'EventDispatcher'})
     const errorObserver = this.getInstance({key: 'ErrorObserverFactory'})
     const positionCreatedObserver = this.getInstance({key: 'PositionCreatedObserver'})
     const positionDisplayedObserver = this.getInstance({key: 'PositionDisplayedObserver'})

--- a/src/openads/infrastructure/connector/appnexus/AppNexusConnector.js
+++ b/src/openads/infrastructure/connector/appnexus/AppNexusConnector.js
@@ -32,11 +32,14 @@ export default class AppNexusConnector extends Connector {
 
   /**
    * Method to define tags.
+   * @param member
+   * @param targetId
    * @param invCode
    * @param sizes
-   * @param targetId
+   * @param keywords
+   * @param native
    */
-  defineTag ({invCode, sizes, targetId}) {
+  defineTag ({member, targetId, invCode, sizes, keywords, native}) {
     throw new Error('AppNexusConnector#defineTag must be implemented')
   }
 
@@ -68,5 +71,19 @@ export default class AppNexusConnector extends Connector {
    */
   refresh (...target) {
     throw new Error('AppNexusConnector#refresh must be implemented')
+  }
+
+  /**
+   * Updates tag information.
+   * @param targetId : an array of ids
+   * @param data : the data to update
+   * @param data.member
+   * @param data.invCode
+   * @param data.sizes
+   * @param data.keywords
+   * @param data.native
+   */
+  modifyTag ({targetId, data}) {
+    throw new Error('AppNexusConnector#modifyTag must be implemented')
   }
 }

--- a/src/openads/infrastructure/connector/appnexus/AppNexusConnector.js
+++ b/src/openads/infrastructure/connector/appnexus/AppNexusConnector.js
@@ -69,7 +69,7 @@ export default class AppNexusConnector extends Connector {
    * Refreshes ads on the page.
    * @param target : an array of ids
    */
-  refresh (...target) {
+  refresh (target) {
     throw new Error('AppNexusConnector#refresh must be implemented')
   }
 

--- a/src/openads/infrastructure/connector/appnexus/AppNexusConnectorImpl.js
+++ b/src/openads/infrastructure/connector/appnexus/AppNexusConnectorImpl.js
@@ -69,7 +69,7 @@ export default class AppNexusConnectorImpl extends AppNexusConnector {
     return this
   }
 
-  refresh (...target) {
+  refresh (target) {
     this._logger.debug('Refresh AppNexus Tag', '| target:', target)
     this._appNexusClient.anq.push(() => this._appNexusClient.refresh(target))
     return this

--- a/src/openads/infrastructure/connector/appnexus/AppNexusConnectorImpl.js
+++ b/src/openads/infrastructure/connector/appnexus/AppNexusConnectorImpl.js
@@ -74,4 +74,10 @@ export default class AppNexusConnectorImpl extends AppNexusConnector {
     this._appNexusClient.anq.push(() => this._appNexusClient.refresh(target))
     return this
   }
+
+  modifyTag ({targetId, data}) {
+    this._logger.debug('Modify AppNexus Tag', '| targetId:', targetId, '| data:', data)
+    this._appNexusClient.anq.push(() => this._appNexusClient.modifyTag(targetId, data))
+    return this
+  }
 }

--- a/src/openads/infrastructure/position/positionSegmentationChangedObserver.js
+++ b/src/openads/infrastructure/position/positionSegmentationChangedObserver.js
@@ -1,9 +1,12 @@
 const positionSegmentationChangedObserverFactory = appnexusConnector => ({payload, dispatcher}) =>
   appnexusConnector
-    .modifyTag(payload.id, {
-      invCode: payload.placement,
-      sizes: payload.sizes,
-      keywords: payload.segmentation
+    .modifyTag({
+      targetId: payload.id,
+      data: {
+        invCode: payload.placement,
+        sizes: payload.sizes,
+        keywords: payload.segmentation
+      }
     })
     .refresh([payload.id])
 

--- a/src/test/openads/infrastructure/connector/appnexus/AppNexusConnectorImplTest.js
+++ b/src/test/openads/infrastructure/connector/appnexus/AppNexusConnectorImplTest.js
@@ -290,9 +290,9 @@ describe('AppNexusConnectorImpl implementation', function () {
       })
 
       const givenPageOpts = {member: 1111, keywords: {p1: 'pv1'}}
-      const givenDefineTag = {member: 2222, targetId: 'Ad1', invCode: 'inv1', sizes: [[1,1]], keywords: {p2: 'pv2'}, native: {}}
+      const givenDefineTag = {member: 2222, targetId: 'Ad1', invCode: 'inv1', sizes: [[1, 1]], keywords: {p2: 'pv2'}, native: {}}
       const givenShowTag = {target: 'Ad1'}
-      const givenModifyTag = {targetId: 'Ad1', data: {member: 2223, invCode: 'inv2', sizes: [[1,1]], keywords: {p3: 'pv3'}, native: {}}}
+      const givenModifyTag = {targetId: 'Ad1', data: {member: 2223, invCode: 'inv2', sizes: [[1, 1]], keywords: {p3: 'pv3'}, native: {}}}
       const givenRefresh = ['Ad1', 'Ad2']
       appNexusConnectorImpl
         .setPageOpts(givenPageOpts)

--- a/src/test/openads/infrastructure/connector/appnexus/AppNexusConnectorImplTest.js
+++ b/src/test/openads/infrastructure/connector/appnexus/AppNexusConnectorImplTest.js
@@ -289,23 +289,32 @@ describe('AppNexusConnectorImpl implementation', function () {
         logger: loggerMock
       })
 
+      const givenPageOpts = {member: 1111, keywords: {p1: 'pv1'}}
+      const givenDefineTag = {member: 2222, targetId: 'Ad1', invCode: 'inv1', sizes: [[1,1]], keywords: {p2: 'pv2'}, native: {}}
+      const givenShowTag = {target: 'Ad1'}
+      const givenModifyTag = {targetId: 'Ad1', data: {member: 2223, invCode: 'inv2', sizes: [[1,1]], keywords: {p3: 'pv3'}, native: {}}}
+      const givenRefresh = ['Ad1', 'Ad2']
       appNexusConnectorImpl
-        .setPageOpts({})
-        .defineTag({})
-        .loadTags({})
-        .showTag({})
-        .modifyTag({})
-        .refresh('1', '2', '3')
+        .setPageOpts(givenPageOpts)
+        .defineTag(givenDefineTag)
+        .loadTags()
+        .showTag(givenShowTag)
+        .modifyTag(givenModifyTag)
+        .refresh(givenRefresh)
 
+      expect(loggerSpy.callCount, 'logger debug method should be called four times').to.equal(6)
       expect(setPageOptsSpy.called).to.be.true
       expect(defineTagSpy.called).to.be.true
       expect(loadTagsSpy.called).to.be.true
       expect(showTagSpy.called).to.be.true
-      expect(loggerSpy.callCount, 'logger debug method should be called four times').to.equal(6)
       expect(modifyTagSpy.called).to.be.true
-      expect(refreshSpy.callCount).equal(1)
-      expect(refreshSpy.lastCall.args.length).equal(1)
-      expect(refreshSpy.lastCall.args[0].length).equal(3)
+      expect(refreshSpy.called).to.be.true
+      expect(setPageOptsSpy.lastCall.args[0]).to.deep.equal(givenPageOpts)
+      expect(defineTagSpy.lastCall.args[0]).to.deep.equal(givenDefineTag)
+      expect(showTagSpy.lastCall.args[0]).to.deep.equal(givenShowTag.target)
+      expect(modifyTagSpy.lastCall.args[0]).to.deep.equal(givenModifyTag.targetId)
+      expect(modifyTagSpy.lastCall.args[1]).to.deep.equal(givenModifyTag.data)
+      expect(refreshSpy.lastCall.args[0]).to.deep.equal(givenRefresh)
     })
   })
 })

--- a/src/test/openads/infrastructure/connector/appnexus/AppNexusConnectorImplTest.js
+++ b/src/test/openads/infrastructure/connector/appnexus/AppNexusConnectorImplTest.js
@@ -267,13 +267,15 @@ describe('AppNexusConnectorImpl implementation', function () {
         defineTag: () => null,
         loadTags: () => null,
         showTag: () => null,
-        refresh: () => null
+        refresh: () => null,
+        modifyTag: () => null
       }
       const setPageOptsSpy = sinon.spy(appNexusClientMock, 'setPageOpts')
       const defineTagSpy = sinon.spy(appNexusClientMock, 'defineTag')
       const loadTagsSpy = sinon.spy(appNexusClientMock, 'loadTags')
       const showTagSpy = sinon.spy(appNexusClientMock, 'showTag')
       const loggerSpy = sinon.spy()
+      const modifyTagSpy = sinon.spy(appNexusClientMock, 'modifyTag')
       const refreshSpy = sinon.spy(appNexusClientMock, 'refresh')
 
       const loggerMock = {
@@ -292,13 +294,15 @@ describe('AppNexusConnectorImpl implementation', function () {
         .defineTag({})
         .loadTags({})
         .showTag({})
+        .modifyTag({})
         .refresh('1', '2', '3')
 
       expect(setPageOptsSpy.called).to.be.true
       expect(defineTagSpy.called).to.be.true
       expect(loadTagsSpy.called).to.be.true
       expect(showTagSpy.called).to.be.true
-      expect(loggerSpy.callCount, 'logger debug method should be called four times').to.equal(5)
+      expect(loggerSpy.callCount, 'logger debug method should be called four times').to.equal(6)
+      expect(modifyTagSpy.called).to.be.true
       expect(refreshSpy.callCount).equal(1)
       expect(refreshSpy.lastCall.args.length).equal(1)
       expect(refreshSpy.lastCall.args[0].length).equal(3)


### PR DESCRIPTION
This PR will:

* fix the refresh method with the missing modifyTag call to apntag
* fix the container eager instances build removing the non used EventDispatcher

![](https://media.giphy.com/media/3oEjI6hkw6nbYNQkz6/giphy.gif)