### PR TITLE
Change for the native definition

### DIFF
--- a/src/openads/application/OpenAds.js
+++ b/src/openads/application/OpenAds.js
@@ -14,10 +14,7 @@ export default class OpenAds {
    * @param {string} placement
    * @param {string} segmentation
    * @param {Array<Array<>>}sizes
-   * @param {Object} native
-   * @param {Function} native.renderer - The function to be used when display use case is used in this position and the Ad is Native type
-   * @param {Object} native.fields - Fields requested to the ad server
-   * @param {string} native.domClickableId - DOM id where will be included the clickable action from native
+   * @param {Object} native - Fields requested to the ad server
    * @returns {Promise<Position>}
    */
   addPosition ({id, name, source, placement, segmentation, sizes, native}) {

--- a/src/openads/application/service/AddPositionUseCase.js
+++ b/src/openads/application/service/AddPositionUseCase.js
@@ -22,10 +22,7 @@ export default class AddPositionUseCase {
    * @param {string} placement
    * @param {string} segmentation
    * @param {Array<Array<>>}sizes
-   * @param {Object} native
-   * @param {Function} native.renderer - The function to be used when display use case is used in this position and the Ad is Native type
-   * @param {Object} native.fields - Fields requested to the ad server
-   * @param {string} native.domClickableId - DOM id where will be included the clickable action from native
+   * @param {Object} native - Fields requested to the ad server
    * @returns {Promise<Position>}
    */
   addPosition ({id, name, source, placement, segmentation, sizes, native}) {

--- a/src/openads/domain/position/Position.js
+++ b/src/openads/domain/position/Position.js
@@ -15,10 +15,7 @@ export default class Position {
    * @param {string} placement
    * @param {string} segmentation
    * @param {Array<Array<>>}sizes
-   * @param {Object} native
-   * @param {Function} native.renderer - The function to be used when display use case is used in this position and the Ad is Native type
-   * @param {Object} native.fields - Fields requested to the ad server
-   * @param {string} native.domClickableId - DOM id where will be included the clickable action from native
+   * @param {Object} native - Fields requested to the ad server
    * @param {Ad} ad - ValueObject width data from the ad loaded in this position
    * @param {string} status - Status of the position
    * @returns {Position}

--- a/src/openads/infrastructure/position/positionCreatedObserver.js
+++ b/src/openads/infrastructure/position/positionCreatedObserver.js
@@ -8,7 +8,7 @@ const positionCreatedObserverFactory = appnexusConnector => appNexusConsumersRep
       invCode: payload.placement,
       sizes: payload.sizes,
       keywords: payload.segmentation,
-      native: payload.native && payload.native.fields
+      native: payload.native
     })
     .onEvent({
       event: AD_AVAILABLE,

--- a/src/test/openads/infrastructure/position/positionCreatedObserverTest.js
+++ b/src/test/openads/infrastructure/position/positionCreatedObserverTest.js
@@ -31,7 +31,7 @@ describe('Position Created Event', function () {
       expect(appnexusConectorOnEventSpy.callCount, 'onEvent should be called five times').to.be.equal(5)
       expect(appnexusConectorLoadTagsSpy.calledOnce, 'loadTags should be called five times').to.be.true
     })
-    it('should send the native.fields as appnexus native tag data in defineTags', function () {
+    it('should send the native data as appnexus native tag data in defineTags', function () {
       const appNexusConsumersRepositoryMock = {}
       this.appnexusConnectorMock = {
         member: 42,
@@ -49,18 +49,16 @@ describe('Position Created Event', function () {
         sizes: [],
         keywords: 'iddqd&idkfa',
         native: {
-          fields: {
-            title: {
-              required: true,
-              max_length: 1000
-            }
+          title: {
+            required: true,
+            max_length: 1000
           }
         }
       }
       positionCreatedObserver({payload})
 
       expect(appnexusConectorDefineTagSpy.calledOnce, 'defineTag should be called once').to.be.true
-      expect(appnexusConectorDefineTagSpy.args[0][0].native, 'defineTag be called with filled native data').to.deep.equal(payload.native.fields)
+      expect(appnexusConectorDefineTagSpy.args[0][0].native, 'defineTag be called with filled native data').to.deep.equal(payload.native)
     })
   })
 })


### PR DESCRIPTION
This PR will
* fix the expected native value to contain explicitly the native fields to request instead of fields+renderer+domClickableId as rendering will be delegated to the OpenAds caller