### PR TITLE
Add the ‘hasPosition’ method to check existing ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenAds 
+# OpenAds
 
 [![Build status](https://travis-ci.org/scm-spain/OpenAds.svg?branch=master)](https://travis-ci.org/scm-spain/OpenAds) [![codecov](https://codecov.io/gh/scm-spain/OpenAds/branch/master/graph/badge.svg)](https://codecov.io/gh/scm-spain/OpenAds)
 
@@ -72,15 +72,15 @@ openAds.addPosition({
           'aa-sch-page_type': 'list',
           'es-sch-adformat': 'x65'
         },
-        sizes: [[300, 250], [320, 250]]    
+        sizes: [[300, 250], [320, 250]]
     }
   }
 })
   .then(position => openAds.displayPosition({id: position.id}))
-  .catch(error => console.log('Do some interesting stuff if there is an error',error))      
+  .catch(error => console.log('Do some interesting stuff if there is an error',error))
 ```
 The Promise response for addPosition is a Position with all data loaded.
-If some error occurred with the connector trying to load the ad inside the position you can deal with it 
+If some error occurred with the connector trying to load the ad inside the position you can deal with it
 using ```catch``` operator from Promise
 
 # Refresh a position
@@ -96,11 +96,11 @@ const positionUpdated = openAds.refreshPosition({
     appnexus: {
       targetId: 'ad1',
       invCode: 'new-placement-to-update',
-      sizes: [[300, 600]]    
+      sizes: [[300, 600]]
     }
   }
-}) 
-  .catch(error => console.log('Maybe new segmentation have generated some kind of error',error))      
+})
+  .catch(error => console.log('Maybe new segmentation have generated some kind of error',error))
 ```
 Keep in mind this two scenarios when you refresh an existent position:
 
@@ -117,7 +117,7 @@ receive a Position as usual but the ad inside will be of type Native.
 
 If you try to do a display of a position that have a Native ad you will get an error of type **PositionAdIsNativeError**.
 
-To request what **fields** you want to receive with the Native ad you can provide that configuration when you add the Position through the native field 
+To request what **fields** you want to receive with the Native ad you can provide that configuration when you add the Position through the native field
 ```ecmascript 6
 openAds.addPosition({
   id: 'ad1',
@@ -160,8 +160,8 @@ openAds.addPosition({
   }
 })
   .then(position => openAds.displayPosition({id: position.id}))
-  .catch(error => console.log('Do some interesting stuff',error))      
-``` 
+  .catch(error => console.log('Do some interesting stuff',error))
+```
 
 # Error handling
 
@@ -189,13 +189,30 @@ openAds.addPosition({
   specification: {}
 })
   .then(position => openAds.displayPosition({id: position.id}))
-  .catch(error => 
+  .catch(error =>
       openAds.refreshPosition({
         id: error.position.id,
         specification: {}
       })
       .then(position => openAds.displayPosition({id: position.id}))
-  )      
+  )
+```
+
+Anyway, you can test for the position to exist to avoid the PositionAlreadyExists error when adding positions:
+
+```ecmascript 6
+openAds.hasPosition({id: 'the_ad'})
+.then(has => has ?
+    openAds.refreshPosition({
+       id: error.position.id,
+       specification: {}
+    })
+    : openAds.addPosition({
+        id: 'the_ad',
+        name: 'some ad',
+        specification: {}
+      })
+      .openAds.displayPosition({id: position.id}))
 ```
 
 # Logging

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -362,7 +362,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -588,7 +588,7 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         }
@@ -1644,7 +1644,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -1834,7 +1834,7 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
@@ -2564,7 +2564,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -5424,13 +5424,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -5525,7 +5525,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -6203,7 +6203,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -6286,7 +6286,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -6457,7 +6457,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -6710,7 +6710,7 @@
     },
     "shelljs": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "OpenAds: Advertising library",
   "main": "dist/",
   "scripts": {

--- a/src/openads/application/OpenAds.js
+++ b/src/openads/application/OpenAds.js
@@ -42,6 +42,16 @@ export default class OpenAds {
   }
 
   /**
+   * Indicates if a position has been previously added
+   * @param id
+   */
+  hasPosition({id}) {
+    return this._container
+      .getInstance({key: 'HasPositionUseCase'})
+      .hasPosition({id})
+  }
+
+  /**
    * Returns current configuration loaded
    * @returns {Object}
    */

--- a/src/openads/application/service/HasPositionUseCase.js
+++ b/src/openads/application/service/HasPositionUseCase.js
@@ -1,0 +1,9 @@
+export default class HasPositionUseCase {
+  constructor({positionRepository}) {
+    this._positionRepository = positionRepository
+  }
+
+  hasPosition({id}) {
+    return this._positionRepository.has({id})
+  }
+}

--- a/src/openads/domain/position/PositionRepository.js
+++ b/src/openads/domain/position/PositionRepository.js
@@ -12,9 +12,17 @@ export default class PositionRepository {
   }
   /**
    * Given a position id will search it on persistence layer
-   * @param {string} id
+   * @param {Promise<Position>} id
    */
   find({id}) {
     throw new Error('PositionRepository#find must be implemented')
+  }
+  /**
+   * Checks for the existence of a Position by id
+   * @param id
+   * @return {Promise<boolean>}
+   */
+  has({id}) {
+    throw new Error('PositionRepository#has must be implemented')
   }
 }

--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -15,6 +15,7 @@ import {POSITION_CREATED} from '../../domain/position/positionCreated'
 import {POSITION_DISPLAYED} from '../../domain/position/positionDisplayed'
 import {POSITION_ALREADY_DISPLAYED} from '../../domain/position/positionAlreadyDisplayed'
 import {POSITION_UPDATED} from '../../domain/position/positionUpdated'
+import HasPositionUseCase from '../../application/service/HasPositionUseCase'
 
 export default class Container {
   constructor({config, eager = true, currentWindow = window} = {}) {
@@ -57,6 +58,12 @@ export default class Container {
       positionRepository: this.getInstance({key: 'PositionRepository'}),
       positionFactory: this.getInstance({key: 'PositionFactory'}),
       adConnectorManager: this.getInstance({key: 'AdConnectorManager'})
+    })
+  }
+
+  _buildHasPositionUseCase() {
+    return new HasPositionUseCase({
+      positionRepository: this.getInstance({key: 'PositionRepository'})
     })
   }
 

--- a/src/openads/infrastructure/position/InMemoryPositionRepository.js
+++ b/src/openads/infrastructure/position/InMemoryPositionRepository.js
@@ -26,4 +26,13 @@ export default class InMemoryPositionRepository extends PositionRepository {
       () => this._positions.has(id) && this._positions.get(id)
     )
   }
+
+  /**
+   * Checks for the existence of a Position by id
+   * @param id
+   * @return {Promise<boolean | never>}
+   */
+  has({id}) {
+    return Promise.resolve().then(() => this._positions.has(id))
+  }
 }

--- a/src/test/openads/application/service/HasPositionUseCaseTest.js
+++ b/src/test/openads/application/service/HasPositionUseCaseTest.js
@@ -1,0 +1,28 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+import HasPositionUseCase from '../../../../openads/application/service/HasPositionUseCase'
+
+describe('HasPositionUseCase test', () => {
+  describe('hasPosition method', () => {
+    it('should call the position repository to check the position existence', done => {
+      const positionRepositoryMock = {
+        has: () => Promise.resolve(true)
+      }
+      const hasSpy = sinon.spy(positionRepositoryMock, 'has')
+      const useCase = new HasPositionUseCase({
+        positionRepository: positionRepositoryMock
+      })
+      useCase
+        .hasPosition({id: 1})
+        .then(result => {
+          expect(hasSpy.calledOnce).to.be.true
+          expect(result).to.be.true
+        })
+        .then(() => done())
+        .catch(err => {
+          expect(err.message).equal('Position 1 not found.')
+          done()
+        })
+    })
+  })
+})

--- a/src/test/openads/infrastructure/position/InMemoryPositionRepositoryTest.js
+++ b/src/test/openads/infrastructure/position/InMemoryPositionRepositoryTest.js
@@ -224,5 +224,101 @@ describe('InMemory Position Repository', function() {
         })
         .catch(error => done(error))
     })
+    it('should say that a position already exists', done => {
+      const inMemoryPositionRepository = new InMemoryPositionRepository({
+        positions: [
+          [
+            '42',
+            {
+              id: '42',
+              name: 'lala',
+              specification: {
+                source: 'appnexus',
+                appnexus: {
+                  placement: 'blabla',
+                  segmentation: 'adsasd',
+                  sizes: [],
+                  native: {}
+                }
+              },
+              status: POSITION_NOT_VISIBLE
+            }
+          ],
+          [
+            '43',
+            {
+              id: '43',
+              name: 'lala43',
+              specification: {
+                source: 'google',
+                google: {
+                  placement: 'blabla',
+                  segmentation: 'adsasd',
+                  sizes: [],
+                  native: {}
+                }
+              },
+              status: POSITION_NOT_VISIBLE
+            }
+          ]
+        ]
+      })
+
+      inMemoryPositionRepository
+        .has({id: '43'})
+        .then(exists => {
+          expect(exists, 'position does not exist').to.be.true
+        })
+        .then(() => done())
+        .catch(error => done(error))
+    })
+    it('should say that a position does not exit', done => {
+      const inMemoryPositionRepository = new InMemoryPositionRepository({
+        positions: [
+          [
+            '42',
+            {
+              id: '42',
+              name: 'lala',
+              specification: {
+                source: 'appnexus',
+                appnexus: {
+                  placement: 'blabla',
+                  segmentation: 'adsasd',
+                  sizes: [],
+                  native: {}
+                }
+              },
+              status: POSITION_NOT_VISIBLE
+            }
+          ],
+          [
+            '43',
+            {
+              id: '43',
+              name: 'lala43',
+              specification: {
+                source: 'google',
+                google: {
+                  placement: 'blabla',
+                  segmentation: 'adsasd',
+                  sizes: [],
+                  native: {}
+                }
+              },
+              status: POSITION_NOT_VISIBLE
+            }
+          ]
+        ]
+      })
+
+      inMemoryPositionRepository
+        .has({id: '55'})
+        .then(exists => {
+          expect(exists, 'position should not exist').to.be.false
+        })
+        .then(() => done())
+        .catch(error => done(error))
+    })
   })
 })


### PR DESCRIPTION
# Background

To check the existence of AppNexus positions, now we have to keep the state of the positions out of OpenAds, or call the AddPosition method expecting a PositionAlreadyExists error.

That's not really nice as OpenAds internally has the state of the IDs that were added, so it could sound better to ask OpenAds if the IDs were added. 

# Goal

Expose a method to ask hasPosition? to OpenAds

# Implementation

Check if an ID already exists into the in-memory position repository

# Further considerations

The problem does not disappear. If we have a position that renders through:
* 1 google call (not implemented yet)
* 1 appnexus call if the google call returns no ads

We'll have to solve:
* The position was  existing before calling the appnexus call or not?
* if in some situation the appnexus call runs directly without the google call (in some device p.ex.), but in a previous call the google call returned an Ad, the appnexus should be added+displayed, not refreshed, so what to do then?

# Checklist

- [X] The PR relates to *only* one subject with a clear title.
- [X] I have performed a self-review of my own code
- [X] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My code is readable by someone else, and I commented the hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

![](https://media.giphy.com/media/uSisFomUKmXGU/giphy.gif)

