### PR TITLE
Hotfix/show error original message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "OpenAds: Advertising library",
   "main": "dist/",
   "scripts": {

--- a/src/openads/infrastructure/bootstrap/BootstrapContext.js
+++ b/src/openads/infrastructure/bootstrap/BootstrapContext.js
@@ -6,7 +6,7 @@ export default class BootstrapContext {
     if (performance) {
       return PerformanceBootstrap.init({config, performance, window})
     } else {
-      return ProductionBootstrap.init({config})
+      return ProductionBootstrap.init({config, window})
     }
   }
 }

--- a/src/openads/infrastructure/bootstrap/ProductionBootstrap.js
+++ b/src/openads/infrastructure/bootstrap/ProductionBootstrap.js
@@ -2,7 +2,9 @@ import OpenAds from '../../application/OpenAds'
 import Container from '../configuration/Container'
 
 export default class ProductionBootstrap {
-  static init({config}) {
-    return new OpenAds({container: new Container({config})})
+  static init({config, window}) {
+    return new OpenAds({
+      container: new Container({config, currentWindow: window})
+    })
   }
 }

--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -50,7 +50,7 @@ export default class Container {
   }
 
   _buildDOMDriver() {
-      return new HTMLDOMDriver({dom: this._currentWindow.document})
+    return new HTMLDOMDriver({dom: this._currentWindow.document})
   }
 
   _buildAddPositionUseCase() {

--- a/src/openads/infrastructure/configuration/Container.js
+++ b/src/openads/infrastructure/configuration/Container.js
@@ -30,7 +30,7 @@ export default class Container {
       try {
         this._instances.set(key, this['_build' + key]())
       } catch (e) {
-        throw new Error(`Error creating instance: ${key}`, e)
+        throw new Error(`Error creating instance: ${key}: ` + e.message)
       }
     }
     return this._instances.get(key)
@@ -50,7 +50,7 @@ export default class Container {
   }
 
   _buildDOMDriver() {
-    return new HTMLDOMDriver({dom: this._currentWindow.document})
+      return new HTMLDOMDriver({dom: this._currentWindow.document})
   }
 
   _buildAddPositionUseCase() {

--- a/src/openads/infrastructure/configuration/PerformanceContainer.js
+++ b/src/openads/infrastructure/configuration/PerformanceContainer.js
@@ -14,7 +14,7 @@ export default class PerformanceContainer extends Container {
       try {
         this._instances.set(key, this['_build' + key]())
       } catch (e) {
-        throw new Error(`Error creating instance: ${key}`, e)
+        throw new Error(`Error creating instance: ${key}: ` + e.message)
       }
     }
     this._performance.stop(`Initializing instance ${key}`)


### PR DESCRIPTION
# Background

Trying to check an error that is originated with a bad window object from command line runner when the performance container is bootstrapped from outter context, I cannot see what's the original error that causes the performance container to fail.

# Goal

Show the error message when the container or the performance container fail to start.

# Checklist

- [X] The PR relates to *only* one subject with a clear title.
- [X] I have performed a self-review of my own code
- [X] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My code is readable by someone else, and I commented the hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

![](https://media.giphy.com/media/Rkis28kMJd1aE/giphy.gif)
