### PR TITLE
Feature/enable debug from local storage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,18 @@
-# Background
+## Description
+<!--- Explain why this PR has to be merged, what originated this feature, ... -->
 
-X
+## Solves ticket/s
+<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->
 
-# Goal
+## Expected behavior
+<!--- Add information of what's expected to happen when this is merged -->
 
-X
+## Review steps
+<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->
 
-# Implementation
+## Further considerations
+<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->
 
-X
-
-# Further considerations
-
-X
-
-# Checklist
-
-- [ ] The PR relates to *only* one subject with a clear title.
-- [ ] I have performed a self-review of my own code
-- [ ] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
-- [ ] My code is readable by someone else, and I commented the hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests that prove my fix is effective or that my feature works
-
+## Memetized description
+<!--- Mandatory gif, try https://giphy.com/  -->
+![mandatory]()

--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ For example:
 http://your.web.app/page?price=5000&openads_debug
 ```
 
+Also, to enable debugger in persistent mode, you can add the option in your browser's local storage from the browser's console:
+```
+window.localStorage.setItem('openads_debug', 'true') // removing it or setting it to false, disables the debugger 
+```
+
+
 Currently, OpenAds uses [LogLevel](https://github.com/pimterry/loglevel) as its logging framework.
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "OpenAds: Advertising library",
   "main": "dist/",
   "scripts": {

--- a/src/itest/openads/infrastructure/configuration/ContainerTest.js
+++ b/src/itest/openads/infrastructure/configuration/ContainerTest.js
@@ -7,15 +7,13 @@ export default class ContainerTest extends Container {
     super({
       config,
       eager: false,
-      currentWindow: new HTMLDOMDriver({
-        dom: new JSDOM('<!DOCTYPE html><div id="forlayo">Hello world</div>')
-          .window
-      })
+      currentWindow: new JSDOM(
+        '<!DOCTYPE html><div id="forlayo">Hello world</div>',
+        {
+          url: 'http://localhost'
+        }
+      ).window
     })
     if (eager) super._buildEagerSingletonInstances()
-  }
-
-  _buildDOMDriver() {
-    return this._currentWindow
   }
 }

--- a/src/itest/openads/infrastructure/configuration/ContainerTest.js
+++ b/src/itest/openads/infrastructure/configuration/ContainerTest.js
@@ -1,5 +1,4 @@
 import Container from '../../../../openads/infrastructure/configuration/Container'
-import HTMLDOMDriver from '../../../../openads/infrastructure/service/HTMLDOMDriver'
 import {JSDOM} from 'jsdom'
 
 export default class ContainerTest extends Container {

--- a/src/openads/domain/service/DOMDriver.js
+++ b/src/openads/domain/service/DOMDriver.js
@@ -25,4 +25,8 @@ export default class DOMDriver {
   getQueryString() {
     throw new Error('DOMDriver#getQueryString must be implemented')
   }
+
+  getLocalStorageValue({key}) {
+    throw new Error('DOMDriver#getLocalStorageValue must be implemented')
+  }
 }

--- a/src/openads/infrastructure/logger/LogLevelLoggerInitializer.js
+++ b/src/openads/infrastructure/logger/LogLevelLoggerInitializer.js
@@ -20,9 +20,17 @@ export default class LogLevelLoggerInitializer {
     return logger
   }
   _isDebugMode() {
+    return (
+      this._enableDebugFromLocalStorage() || this._enableDebugFromQueryString()
+    )
+  }
+  _enableDebugFromLocalStorage() {
+    return this._domDriver.getLocalStorageValue({key: DEBUG_KEY}) === 'true'
+  }
+  _enableDebugFromQueryString() {
     const queryString = this._domDriver.getQueryString()
     const parameters = QS.parse(queryString)
-    return parameters[this._loggerName.toLowerCase() + '_debug'] !== undefined
+    return parameters[DEBUG_KEY] !== undefined
   }
   _enableConnectorsDebug() {
     Object.values(this._connectors).forEach(connector => {
@@ -37,3 +45,4 @@ export default class LogLevelLoggerInitializer {
     })
   }
 }
+const DEBUG_KEY = 'openads_debug'

--- a/src/openads/infrastructure/service/HTMLDOMDriver.js
+++ b/src/openads/infrastructure/service/HTMLDOMDriver.js
@@ -32,4 +32,8 @@ export default class HTMLDOMDriver extends DOMDriver {
   getQueryString() {
     return this._dom.location.search.slice(1)
   }
+
+  getLocalStorageValue({key}) {
+    return this._dom.defaultView.localStorage.getItem(key)
+  }
 }

--- a/src/test/openads/infrastructure/logger/LogLevelInitializerTest.js
+++ b/src/test/openads/infrastructure/logger/LogLevelInitializerTest.js
@@ -4,8 +4,9 @@ import LogLevelLoggerInitializer from '../../../../openads/infrastructure/logger
 
 describe('LogLevel Logger Initializer', () => {
   const givenLoggerName = 'OpenAds'
-  it('Should use error as default level if no DEBUG option is in URL', () => {
+  it('Should use error as default level if no DEBUG option is set', () => {
     const givenSearch = ''
+    const givenLocalStorageValue = null
     const loggerMock = {
       setLevel: level => null
     }
@@ -13,7 +14,8 @@ describe('LogLevel Logger Initializer', () => {
       getLogger: loggerName => loggerMock
     }
     const domDriverMock = {
-      getQueryString: () => givenSearch
+      getQueryString: () => givenSearch,
+      getLocalStorageValue: () => givenLocalStorageValue
     }
 
     const setLevelSpy = sinon.spy(loggerMock, 'setLevel')
@@ -29,6 +31,7 @@ describe('LogLevel Logger Initializer', () => {
   })
   it('Should use debug as level if DEBUG option is in URL, enabling debug to any connector implementing Logger interface', () => {
     const givenSearch = '?a=a&openads_debug&b=b'
+    const givenLocalStorageValue = 'false'
     const loggerMock = {
       setLevel: level => null
     }
@@ -36,7 +39,8 @@ describe('LogLevel Logger Initializer', () => {
       getLogger: loggerName => loggerMock
     }
     const domDriverMock = {
-      getQueryString: () => givenSearch
+      getQueryString: () => givenSearch,
+      getLocalStorageValue: () => givenLocalStorageValue
     }
     const fooLoggerConnector = {
       enableDebug: ({debug}) => null
@@ -65,5 +69,30 @@ describe('LogLevel Logger Initializer', () => {
     expect(setLevelSpy.args[0][0]).to.equal('debug')
     expect(setConnectorEnableDebugSpy.calledOnce).to.be.true
     expect(setConnectorEnableDebugSpy.args[0][0].debug).to.be.true
+  })
+  it('Should enable DEBUG if the openads_debug option is set in local storage', () => {
+    const givenSearch = ''
+    const givenLocalStorageValue = 'true'
+    const loggerMock = {
+      setLevel: level => null
+    }
+    const logLevelMock = {
+      getLogger: loggerName => loggerMock
+    }
+    const domDriverMock = {
+      getQueryString: () => givenSearch,
+      getLocalStorageValue: () => givenLocalStorageValue
+    }
+
+    const setLevelSpy = sinon.spy(loggerMock, 'setLevel')
+
+    const logLevelInitializer = new LogLevelLoggerInitializer({
+      logLevel: logLevelMock,
+      domDriver: domDriverMock,
+      loggerName: givenLoggerName
+    })
+    logLevelInitializer.logger()
+    expect(setLevelSpy.calledOnce).to.be.true
+    expect(setLevelSpy.args[0][0]).to.equal('debug')
   })
 })

--- a/src/test/openads/infrastructure/service/HTMLDOMDriverTest.js
+++ b/src/test/openads/infrastructure/service/HTMLDOMDriverTest.js
@@ -174,4 +174,19 @@ describe('DOM Driver HTML simple implementation', function() {
     const queryString = htmlDOMDriver.getQueryString()
     expect(queryString).to.equal('')
   })
+  it('Should get a value from the local storage', () => {
+    const givenDocument = new JSDOM(
+      '<!DOCTYPE html><div id="forlayo">Hello world</div>',
+      {
+        url: 'http://localhost'
+      }
+    ).window.document
+    const givenKey = 'aKey'
+    const givenValue = 'aValue'
+    givenDocument.defaultView.localStorage.setItem(givenKey, givenValue)
+
+    const htmlDOMDriver = new HTMLDOMDriver({dom: givenDocument})
+    const result = htmlDOMDriver.getLocalStorageValue({key: givenKey})
+    expect(result).to.equal(givenValue)
+  })
 })


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

This PR adds the option to enable DEBUG using the browser's local storage instead of looking only for the value in the query string.

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* if _window.localStorage.getItem('openads_debug') === 'true'_ the DEBUG mode will be enabled
* if not, the query string will be parsed to look for the debug option as the current version does

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/NMufrvxO8fC3C/giphy.gif)