### PR TITLE
catch exception accessing to localStorage

### DIFF
--- a/src/openads/infrastructure/service/HTMLDOMDriver.js
+++ b/src/openads/infrastructure/service/HTMLDOMDriver.js
@@ -34,6 +34,10 @@ export default class HTMLDOMDriver extends DOMDriver {
   }
 
   getLocalStorageValue({key}) {
-    return this._dom.defaultView.localStorage.getItem(key)
+    try {
+      return this._dom.defaultView.localStorage.getItem(key)
+    } catch (error) {
+      return ''
+    }
   }
 }


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Error events are showing that the context container cannot be initialized in some clients due to errors in Logger initialization. That's an error that was solved into the OpenAds' client side catching the error when the JS has no access to the user's localStorage space.

![image](https://user-images.githubusercontent.com/20399660/74940737-29ff2700-53f2-11ea-8c26-8b843a5a1e04.png)

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-2881

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* this kind of errors disappear from our metrics 

kibana query

```
kubernetes.labels.app:"ms-adit--mushroom" AND INITIALIZATION_ERROR AND "Error creating instance: Logger"
```

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

* cannot reproduce in local, just applied same logic that was applied to solve the same problem in the OpenAds client

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/VHlRuYl8CJaN5Jshp4/giphy.gif)