### PR TITLE
feat: refine PositionAdNotAvailable errors

### DIFF
--- a/src/itest/openads/AddPositionUseCaseTest.js
+++ b/src/itest/openads/AddPositionUseCaseTest.js
@@ -126,7 +126,7 @@ describe('Add Position use case', function() {
           expect(
             error.name,
             `AddPosition return a rejected Promise, in this case, we expect an error with name: 'PositionAdNotAvailableError', but we have received a ${error.name}`
-          ).to.be.equals('PositionAdNotAvailableError')
+          ).to.be.equals('PositionAdError')
           expect(
             error.position.id,
             `AddPosition return a rejected Promise, in this case, we expect that the position id was: 'ad1', but we have received a position id ${error.position.id}`

--- a/src/openads/application/service/AddPositionUseCase.js
+++ b/src/openads/application/service/AddPositionUseCase.js
@@ -71,10 +71,10 @@ export default class AddPositionUseCase {
 
   _filterPositionAdIsAvailable(position) {
     if (position.ad.status !== AD_AVAILABLE) {
-      if (position.ad.data && position.ad.data.errMessage) {
-        throw new PositionAdError({position})
-      } else {
+      if (position.ad.data && position.ad.data.nobid) {
         throw new PositionAdNotAvailableError({position})
+      } else {
+        throw new PositionAdError({position})
       }
     }
     return position

--- a/src/openads/domain/position/PositionAdError.js
+++ b/src/openads/domain/position/PositionAdError.js
@@ -2,9 +2,11 @@ export default class PositionAdError extends Error {
   constructor({position = {}} = {}) {
     super()
     this.name = 'PositionAdError'
-    this.message = `Error loading Ad ${position.id}: ${(position.ad &&
-      position.ad.data &&
-      position.ad.data.errMessage) ||
+    let msg = position.ad && position.ad.data && position.ad.data.errMessage
+    if (!msg && typeof position.ad.data === 'string') {
+      msg = position.ad.data
+    }
+    this.message = `Error loading Ad ${position.id}: ${msg ||
       'unexpected error'}.`
     this.stack = new Error().stack
     this.position = position

--- a/src/test/openads/application/service/AddPositionUseCaseTest.js
+++ b/src/test/openads/application/service/AddPositionUseCaseTest.js
@@ -183,13 +183,13 @@ describe('Add Position use case', function() {
           done(new Error('Should fail with position not available error'))
         })
         .catch(error => {
-          expect(error.name).to.equal('PositionAdNotAvailableError')
+          expect(error.name).to.equal('PositionAdError')
           expect(error.position.ad.status).to.equal(AD_ERROR)
           done()
         })
     })
     it('should return the position with an unresolved Ad with AD_NO_BID status ad server returns a adNoBid response', function(done) {
-      const givenAd = {data: 'ad no bid', status: AD_NO_BID}
+      const givenAd = {data: {nobid: true}, status: AD_NO_BID}
       const givenPositionRequest = {
         id: 'ad-1',
         name: 'TOP',


### PR DESCRIPTION
## Description
During the migration to TCF in MA we notice that timeouts where reported as AdNotAvailable.
This PR tries to define the errors PositionAdNotAvailable only the adserver nobid responses

**Problem today**
Mushroom trace when a timeout occurs
<img width="895" alt="Screenshot 2020-08-12 at 14 29 54" src="https://user-images.githubusercontent.com/45286922/90015057-52345800-dca8-11ea-9880-05deb7d6c4c0.png">


## Expected behavior
When a timeout occurs will report an AD_ERROR
<img width="940" alt="Screenshot 2020-08-12 at 14 22 03" src="https://user-images.githubusercontent.com/45286922/90014844-fff33700-dca7-11ea-95df-e9f5ef48bb9d.png">

## Review steps
Link in scmspainads and then in client MA. Slow connection in performance to Fast 3g. Go to a listing in MA. Remove euconsent-v2 and refresh. Don't accept the consent. in 30 seconds the timeout occurs and produces a the traces and tracks to mushroom. 

## Memetized description
![mandatory](https://media.giphy.com/media/Q591S2nXc4W6kaWLkG/giphy.gif)