### PR TITLE
fix error message generation

### DIFF
--- a/src/openads/domain/position/PositionAdError.js
+++ b/src/openads/domain/position/PositionAdError.js
@@ -2,12 +2,13 @@ export default class PositionAdError extends Error {
   constructor({position = {}} = {}) {
     super()
     this.name = 'PositionAdError'
-    let msg = position.ad && position.ad.data && position.ad.data.errMessage
-    if (!msg && typeof position.ad.data === 'string') {
-      msg = position.ad.data
-    }
-    this.message = `Error loading Ad ${position.id}: ${msg ||
-      'unexpected error'}.`
+    const errorMessage =
+      position.ad &&
+      position.ad.data &&
+      (typeof position.ad.data === 'string'
+        ? position.ad.data
+        : position.ad.data.errMessage || 'unexpected error')
+    this.message = `Error loading Ad ${position.id}: ${errorMessage}.`
     this.stack = new Error().stack
     this.position = position
   }

--- a/src/openads/domain/position/PositionAdError.js
+++ b/src/openads/domain/position/PositionAdError.js
@@ -3,11 +3,11 @@ export default class PositionAdError extends Error {
     super()
     this.name = 'PositionAdError'
     const errorMessage =
-      position.ad &&
-      position.ad.data &&
-      (typeof position.ad.data === 'string'
-        ? position.ad.data
-        : position.ad.data.errMessage || 'unexpected error')
+      (position.ad &&
+        position.ad.data &&
+        (position.ad.data.errMessage ||
+          (typeof position.ad.data === 'string' && position.ad.data))) ||
+      'unexpected error'
     this.message = `Error loading Ad ${position.id}: ${errorMessage}.`
     this.stack = new Error().stack
     this.position = position


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

In last version we introduced a bug generating the error message, that occurs when an error is thrown but no `position.ad` is filled by the connector.
In that case, previously we were setting the "unexpected error" message.

![image](https://user-images.githubusercontent.com/20399660/90136319-48782680-dd74-11ea-9823-03a0d0e26bcf.png)

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/7ixpj8MU0EhwY/giphy.gif)